### PR TITLE
Fix: don't crash when token refresh fails but access token is valid

### DIFF
--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -81,7 +81,9 @@ export async function getClient(): Promise<QuickBooks> {
     credentials.refresh_token
   );
 
-  // Refresh the access token
+  // Try to refresh the access token — but proceed with the current token if refresh fails,
+  // since the existing access token may still be valid (e.g. just obtained via OAuth exchange)
+  let refreshed = false;
   try {
     const tokenInfo = await promisify<{
       access_token: string;
@@ -92,34 +94,40 @@ export async function getClient(): Promise<QuickBooks> {
     credentials.access_token = tokenInfo.access_token;
     credentials.refresh_token = tokenInfo.refresh_token;
     await provider.saveCredentials(credentials);
+    refreshed = true;
   } catch (refreshError) {
     // For local mode, try using intuit-oauth for refresh as a fallback
     if (isLocalMode()) {
       try {
         credentials = await refreshAccessToken(credentials);
         await provider.saveCredentials(credentials);
-      } catch (fallbackError) {
-        // If both methods fail, throw the original error
-        throw refreshError;
+        refreshed = true;
+      } catch (_fallbackError) {
+        // Both refresh methods failed — proceed with current access token.
+        // It may still be valid if recently obtained.
       }
-    } else {
+    }
+    // In AWS mode, refresh failure is fatal (no fallback)
+    if (!isLocalMode()) {
       throw refreshError;
     }
   }
 
-  // Recreate client with new tokens
-  qbo = new QuickBooks(
-    credentials.client_id,
-    credentials.client_secret,
-    credentials.access_token,
-    false,
-    companyId,
-    useSandbox,
-    false, // Debug mode off
-    null,
-    "2.0",
-    credentials.refresh_token
-  );
+  // Recreate client with (possibly refreshed) tokens
+  if (refreshed) {
+    qbo = new QuickBooks(
+      credentials.client_id,
+      credentials.client_secret,
+      credentials.access_token,
+      false,
+      companyId,
+      useSandbox,
+      false, // Debug mode off
+      null,
+      "2.0",
+      credentials.refresh_token
+    );
+  }
 
   return qbo;
 }


### PR DESCRIPTION
Ran into this while setting up the server for the first time. After completing the OAuth flow and getting valid tokens, every API call would fail with a 400 because `getClient()` tries to refresh the access token before each request — and the refresh was failing.

## The problem

In `src/client/auth.ts`, `getClient()` unconditionally calls `refreshAccessToken()` before making any API call. If both refresh methods fail (node-quickbooks and the intuit-oauth fallback), the function throws — even when the access token it already has is perfectly valid.

This happens reliably right after the initial OAuth exchange: you get a fresh access token, but the refresh token hasn't "settled" yet (or in my case, the Intuit Playground page had consumed the auth code first, leaving the refresh token in a bad state). The access token works fine for API calls, but the refresh blows up and takes everything with it.

## The fix

In local mode, if both refresh attempts fail, proceed with the existing access token instead of throwing. The token may still be valid — especially right after OAuth exchange. If it turns out to be expired, the existing auth retry logic in `executeTool()` will catch the 401 and retry.

AWS mode still fails fast on refresh failure since there's no interactive fallback available.

## How I found it

Verified by calling the QuickBooks API directly with `fetch()` using the access token from the credentials file — it returned 200 with valid company data. The token was fine; only the refresh was broken.