### PR TITLE
Add vendor CRUD tools (create, get, edit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,10 @@ QBO_INLINE_OUTPUT=true
 | `create_vendor_credit` | Create a vendor credit |
 | `get_vendor_credit` | Fetch a vendor credit by ID |
 | `edit_vendor_credit` | Modify an existing vendor credit |
+| **Vendors** | |
+| `create_vendor` | Create a vendor with contact info, 1099 status, and payment terms |
+| `get_vendor` | Fetch a vendor by ID (tax ID returned masked) |
+| `edit_vendor` | Modify an existing vendor (set active=false to deactivate) |
 | **Delete** | |
 | `delete_entity` | Delete any transaction (journal entry, bill, invoice, deposit, sales receipt, expense, vendor credit) |
 

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -1615,4 +1615,225 @@ export const toolDefinitions = [
       required: ["id"],
     },
   },
+  // --- Vendor tools ---
+  {
+    name: "create_vendor",
+    description: "Create a vendor. Accepts name parts, contact info, address, 1099 status, and payment terms. Returns vendor details and a link to view in QuickBooks.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        display_name: {
+          type: "string",
+          description: "Primary display name (must be unique across Customers, Employees, and Vendors)",
+        },
+        given_name: {
+          type: "string",
+          description: "First/given name (optional)",
+        },
+        middle_name: {
+          type: "string",
+          description: "Middle name (optional)",
+        },
+        family_name: {
+          type: "string",
+          description: "Last/family name (optional)",
+        },
+        suffix: {
+          type: "string",
+          description: "Name suffix, e.g., 'Jr.' (optional)",
+        },
+        title: {
+          type: "string",
+          description: "Name title, e.g., 'Mr.', 'Ms.' (optional)",
+        },
+        company_name: {
+          type: "string",
+          description: "Company name (optional)",
+        },
+        print_on_check_name: {
+          type: "string",
+          description: "Name printed on checks (defaults to DisplayName if not set)",
+        },
+        email: {
+          type: "string",
+          description: "Primary email address (optional)",
+        },
+        phone: {
+          type: "string",
+          description: "Primary phone number (optional)",
+        },
+        mobile: {
+          type: "string",
+          description: "Mobile phone number (optional)",
+        },
+        fax: {
+          type: "string",
+          description: "Fax number (optional)",
+        },
+        website: {
+          type: "string",
+          description: "Website URL (optional)",
+        },
+        bill_address: {
+          type: "object",
+          description: "Billing address (optional)",
+          properties: {
+            line1: { type: "string" },
+            line2: { type: "string" },
+            line3: { type: "string" },
+            city: { type: "string" },
+            country_sub_division_code: { type: "string", description: "State/province code" },
+            postal_code: { type: "string" },
+            country: { type: "string" },
+          },
+        },
+        acct_num: {
+          type: "string",
+          description: "Your account number with this vendor (optional)",
+        },
+        vendor_1099: {
+          type: "boolean",
+          description: "Whether this vendor is tracked for 1099 reporting",
+        },
+        tax_identifier: {
+          type: "string",
+          description: "Vendor's tax ID (SSN or EIN). Write-only: reads back masked as XXXXX1234.",
+        },
+        term_ref: {
+          type: "string",
+          description: "Default payment terms name (e.g., 'Net 30'). Will be looked up to get ID.",
+        },
+        bill_rate: {
+          type: "number",
+          description: "Default billing rate for this vendor (optional)",
+        },
+        draft: {
+          type: "boolean",
+          description: "If true, validate and show preview without creating (default: true)",
+        },
+      },
+      required: ["display_name"],
+    },
+  },
+  {
+    name: "get_vendor",
+    description: "Fetch a single vendor by ID with full details including SyncToken (needed for edits). Returns name, contact info, address, 1099 status, tax ID (masked), payment terms, balance, and active status.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          description: "The vendor ID",
+        },
+      },
+      required: ["id"],
+    },
+  },
+  {
+    name: "edit_vendor",
+    description: "Modify an existing vendor. Can update name, contact info, address, 1099 status, tax ID, payment terms, and active status. Set active=false to deactivate (vendors cannot be deleted in QuickBooks).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          description: "Vendor ID to edit",
+        },
+        display_name: {
+          type: "string",
+          description: "New display name (must be unique)",
+        },
+        given_name: {
+          type: "string",
+          description: "New first/given name",
+        },
+        middle_name: {
+          type: "string",
+          description: "New middle name",
+        },
+        family_name: {
+          type: "string",
+          description: "New last/family name",
+        },
+        suffix: {
+          type: "string",
+          description: "New name suffix",
+        },
+        title: {
+          type: "string",
+          description: "New name title",
+        },
+        company_name: {
+          type: "string",
+          description: "New company name",
+        },
+        print_on_check_name: {
+          type: "string",
+          description: "New check name",
+        },
+        email: {
+          type: "string",
+          description: "New primary email address",
+        },
+        phone: {
+          type: "string",
+          description: "New primary phone number",
+        },
+        mobile: {
+          type: "string",
+          description: "New mobile phone number",
+        },
+        fax: {
+          type: "string",
+          description: "New fax number",
+        },
+        website: {
+          type: "string",
+          description: "New website URL",
+        },
+        bill_address: {
+          type: "object",
+          description: "New billing address",
+          properties: {
+            line1: { type: "string" },
+            line2: { type: "string" },
+            line3: { type: "string" },
+            city: { type: "string" },
+            country_sub_division_code: { type: "string", description: "State/province code" },
+            postal_code: { type: "string" },
+            country: { type: "string" },
+          },
+        },
+        acct_num: {
+          type: "string",
+          description: "New account number with this vendor",
+        },
+        vendor_1099: {
+          type: "boolean",
+          description: "Whether to track this vendor for 1099 reporting",
+        },
+        tax_identifier: {
+          type: "string",
+          description: "New tax ID (SSN or EIN). Write-only: reads back masked.",
+        },
+        term_ref: {
+          type: "string",
+          description: "New payment terms name (e.g., 'Net 30'). Auto-resolved to ID.",
+        },
+        bill_rate: {
+          type: "number",
+          description: "New default billing rate",
+        },
+        active: {
+          type: "boolean",
+          description: "Set to false to deactivate vendor (QuickBooks equivalent of delete)",
+        },
+        draft: {
+          type: "boolean",
+          description: "If true, validate and show preview without saving (default: true)",
+        },
+      },
+      required: ["id"],
+    },
+  },
 ];

--- a/src/tools/handlers/index.ts
+++ b/src/tools/handlers/index.ts
@@ -22,5 +22,6 @@ export { handleCreateInvoice, handleGetInvoice, handleEditInvoice } from './invo
 export { handleCreateDeposit, handleGetDeposit, handleEditDeposit } from './deposit.js';
 export { handleCreateVendorCredit, handleGetVendorCredit, handleEditVendorCredit } from './vendor-credit.js';
 export { handleCreateCustomer, handleGetCustomer, handleEditCustomer } from './customer.js';
+export { handleCreateVendor, handleGetVendor, handleEditVendor } from './vendor.js';
 export { handleDeleteEntity } from './delete.js';
 export { handleAuthenticate } from './authenticate.js';

--- a/src/tools/handlers/vendor.ts
+++ b/src/tools/handlers/vendor.ts
@@ -1,0 +1,380 @@
+// Handlers for vendor tools (create, get, edit)
+
+import QuickBooks from "node-quickbooks";
+import { promisify } from "../../client/index.js";
+import { outputReport } from "../../utils/index.js";
+
+interface AddressInput {
+  line1?: string;
+  line2?: string;
+  line3?: string;
+  city?: string;
+  country_sub_division_code?: string;
+  postal_code?: string;
+  country?: string;
+}
+
+interface QBAddress {
+  Line1?: string;
+  Line2?: string;
+  Line3?: string;
+  City?: string;
+  CountrySubDivisionCode?: string;
+  PostalCode?: string;
+  Country?: string;
+}
+
+function buildQBAddress(input: AddressInput): QBAddress {
+  const addr: QBAddress = {};
+  if (input.line1) addr.Line1 = input.line1;
+  if (input.line2) addr.Line2 = input.line2;
+  if (input.line3) addr.Line3 = input.line3;
+  if (input.city) addr.City = input.city;
+  if (input.country_sub_division_code) addr.CountrySubDivisionCode = input.country_sub_division_code;
+  if (input.postal_code) addr.PostalCode = input.postal_code;
+  if (input.country) addr.Country = input.country;
+  return addr;
+}
+
+function formatAddress(addr: QBAddress | undefined, label: string): string[] {
+  if (!addr) return [`${label}: (none)`];
+  const parts: string[] = [];
+  for (const key of ['Line1', 'Line2', 'Line3'] as const) {
+    if (addr[key]) parts.push(addr[key]!);
+  }
+  if (addr.City || addr.CountrySubDivisionCode || addr.PostalCode) {
+    const cityState = [addr.City, addr.CountrySubDivisionCode].filter(Boolean).join(', ');
+    parts.push([cityState, addr.PostalCode].filter(Boolean).join(' '));
+  }
+  if (addr.Country) parts.push(addr.Country);
+  if (parts.length === 0) return [`${label}: (none)`];
+  return [`${label}:`, ...parts.map(p => `  ${p}`)];
+}
+
+interface QBVendor {
+  Id: string;
+  SyncToken: string;
+  DisplayName: string;
+  GivenName?: string;
+  MiddleName?: string;
+  FamilyName?: string;
+  Suffix?: string;
+  Title?: string;
+  CompanyName?: string;
+  PrintOnCheckName?: string;
+  PrimaryEmailAddr?: { Address?: string };
+  PrimaryPhone?: { FreeFormNumber?: string };
+  Mobile?: { FreeFormNumber?: string };
+  Fax?: { FreeFormNumber?: string };
+  WebAddr?: { URI?: string };
+  BillAddr?: QBAddress;
+  AcctNum?: string;
+  Vendor1099?: boolean;
+  TaxIdentifier?: string;
+  TermRef?: { value: string; name?: string };
+  Balance?: number;
+  Active?: boolean;
+  BillRate?: number;
+  CurrencyRef?: { value: string; name?: string };
+  MetaData?: { CreateTime?: string; LastUpdatedTime?: string };
+}
+
+export async function handleCreateVendor(
+  client: QuickBooks,
+  args: {
+    display_name: string;
+    given_name?: string;
+    middle_name?: string;
+    family_name?: string;
+    suffix?: string;
+    title?: string;
+    company_name?: string;
+    print_on_check_name?: string;
+    email?: string;
+    phone?: string;
+    mobile?: string;
+    fax?: string;
+    website?: string;
+    bill_address?: AddressInput;
+    acct_num?: string;
+    vendor_1099?: boolean;
+    tax_identifier?: string;
+    term_ref?: string;
+    bill_rate?: number;
+    draft?: boolean;
+  }
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const {
+    display_name, given_name, middle_name, family_name, suffix, title,
+    company_name, print_on_check_name, email, phone, mobile, fax, website,
+    bill_address, acct_num, vendor_1099, tax_identifier, term_ref, bill_rate,
+    draft = true,
+  } = args;
+
+  const vendorObj: Record<string, unknown> = {
+    DisplayName: display_name,
+  };
+  if (given_name) vendorObj.GivenName = given_name;
+  if (middle_name) vendorObj.MiddleName = middle_name;
+  if (family_name) vendorObj.FamilyName = family_name;
+  if (suffix) vendorObj.Suffix = suffix;
+  if (title) vendorObj.Title = title;
+  if (company_name) vendorObj.CompanyName = company_name;
+  if (print_on_check_name) vendorObj.PrintOnCheckName = print_on_check_name;
+  if (email) vendorObj.PrimaryEmailAddr = { Address: email };
+  if (phone) vendorObj.PrimaryPhone = { FreeFormNumber: phone };
+  if (mobile) vendorObj.Mobile = { FreeFormNumber: mobile };
+  if (fax) vendorObj.Fax = { FreeFormNumber: fax };
+  if (website) vendorObj.WebAddr = { URI: website };
+  if (bill_address) vendorObj.BillAddr = buildQBAddress(bill_address);
+  if (acct_num) vendorObj.AcctNum = acct_num;
+  if (vendor_1099 !== undefined) vendorObj.Vendor1099 = vendor_1099;
+  if (tax_identifier) vendorObj.TaxIdentifier = tax_identifier;
+  if (bill_rate !== undefined) vendorObj.BillRate = bill_rate;
+
+  // Resolve payment terms
+  let termName: string | undefined;
+  if (term_ref) {
+    const terms = await promisify<{ QueryResponse: { Term?: Array<{ Id: string; Name: string }> } }>((cb) =>
+      (client as unknown as Record<string, Function>).findTerms(cb)
+    );
+    const termList = terms.QueryResponse?.Term || [];
+    const match = termList.find(t =>
+      t.Name.toLowerCase() === term_ref.toLowerCase() ||
+      t.Id === term_ref
+    );
+    if (!match) {
+      const available = termList.map(t => t.Name).join(', ');
+      throw new Error(`Term not found: "${term_ref}". Available: ${available}`);
+    }
+    vendorObj.TermRef = { value: match.Id, name: match.Name };
+    termName = match.Name;
+  }
+
+  if (draft) {
+    const preview = [
+      "DRAFT - Vendor Preview",
+      "",
+      `Display Name: ${display_name}`,
+      ...(given_name || middle_name || family_name || suffix || title
+        ? [`Name Parts: ${[title, given_name, middle_name, family_name, suffix].filter(Boolean).join(' ')}`]
+        : []),
+      `Company: ${company_name || "(none)"}`,
+      `Print on Check: ${print_on_check_name || "(default)"}`,
+      `Email: ${email || "(none)"}`,
+      `Phone: ${phone || "(none)"}`,
+      `Mobile: ${mobile || "(none)"}`,
+      `Fax: ${fax || "(none)"}`,
+      `Website: ${website || "(none)"}`,
+      ...formatAddress(bill_address ? buildQBAddress(bill_address) : undefined, "Address"),
+      `Account #: ${acct_num || "(none)"}`,
+      `1099 Vendor: ${vendor_1099 !== undefined ? vendor_1099 : "(default)"}`,
+      `Tax ID: ${tax_identifier ? "(provided)" : "(none)"}`,
+      ...(termName ? [`Terms: ${termName}`] : []),
+      ...(bill_rate !== undefined ? [`Bill Rate: ${bill_rate}`] : []),
+      "",
+      "Set draft=false to create this vendor.",
+    ].join("\n");
+
+    return { content: [{ type: "text", text: preview }] };
+  }
+
+  const result = await promisify<unknown>((cb) =>
+    (client as unknown as Record<string, Function>).createVendor(vendorObj, cb)
+  ) as QBVendor;
+
+  const qboUrl = `https://app.qbo.intuit.com/app/vendordetail?nameId=${result.Id}`;
+
+  const response = [
+    "Vendor Created!",
+    "",
+    `ID: ${result.Id}`,
+    `Display Name: ${result.DisplayName}`,
+    "",
+    `View in QuickBooks: ${qboUrl}`,
+  ].join("\n");
+
+  return { content: [{ type: "text", text: response }] };
+}
+
+export async function handleGetVendor(
+  client: QuickBooks,
+  args: { id: string }
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const { id } = args;
+
+  const vendor = await promisify<unknown>((cb) =>
+    (client as unknown as Record<string, Function>).getVendor(id, cb)
+  ) as QBVendor;
+
+  const qboUrl = `https://app.qbo.intuit.com/app/vendordetail?nameId=${vendor.Id}`;
+
+  const lines: string[] = [
+    "Vendor",
+    "======",
+    `ID: ${vendor.Id}`,
+    `SyncToken: ${vendor.SyncToken}`,
+    `Display Name: ${vendor.DisplayName}`,
+    `Active: ${vendor.Active !== false}`,
+  ];
+
+  if (vendor.Title || vendor.GivenName || vendor.MiddleName || vendor.FamilyName || vendor.Suffix) {
+    lines.push(`Name: ${[vendor.Title, vendor.GivenName, vendor.MiddleName, vendor.FamilyName, vendor.Suffix].filter(Boolean).join(' ')}`);
+  }
+  if (vendor.CompanyName) lines.push(`Company: ${vendor.CompanyName}`);
+  if (vendor.PrintOnCheckName) lines.push(`Print on Check: ${vendor.PrintOnCheckName}`);
+  lines.push(`Email: ${vendor.PrimaryEmailAddr?.Address || "(none)"}`);
+  lines.push(`Phone: ${vendor.PrimaryPhone?.FreeFormNumber || "(none)"}`);
+  if (vendor.Mobile?.FreeFormNumber) lines.push(`Mobile: ${vendor.Mobile.FreeFormNumber}`);
+  if (vendor.Fax?.FreeFormNumber) lines.push(`Fax: ${vendor.Fax.FreeFormNumber}`);
+  if (vendor.WebAddr?.URI) lines.push(`Website: ${vendor.WebAddr.URI}`);
+  lines.push(...formatAddress(vendor.BillAddr, "Address"));
+  if (vendor.AcctNum) lines.push(`Account #: ${vendor.AcctNum}`);
+  lines.push(`1099 Vendor: ${vendor.Vendor1099 ?? false}`);
+  if (vendor.TaxIdentifier) lines.push(`Tax ID: ${vendor.TaxIdentifier}`);
+  lines.push(`Terms: ${vendor.TermRef?.name || "(none)"}`);
+  if (vendor.BillRate !== undefined) lines.push(`Bill Rate: ${vendor.BillRate}`);
+  lines.push(`Balance: $${(vendor.Balance || 0).toFixed(2)}`);
+  if (vendor.CurrencyRef) lines.push(`Currency: ${vendor.CurrencyRef.name || vendor.CurrencyRef.value}`);
+  lines.push("");
+  lines.push(`View in QuickBooks: ${qboUrl}`);
+
+  return outputReport(`vendor-${vendor.Id}`, vendor, lines.join("\n"));
+}
+
+export async function handleEditVendor(
+  client: QuickBooks,
+  args: {
+    id: string;
+    display_name?: string;
+    given_name?: string;
+    middle_name?: string;
+    family_name?: string;
+    suffix?: string;
+    title?: string;
+    company_name?: string;
+    print_on_check_name?: string;
+    email?: string;
+    phone?: string;
+    mobile?: string;
+    fax?: string;
+    website?: string;
+    bill_address?: AddressInput;
+    acct_num?: string;
+    vendor_1099?: boolean;
+    tax_identifier?: string;
+    term_ref?: string;
+    bill_rate?: number;
+    active?: boolean;
+    draft?: boolean;
+  }
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const {
+    id, display_name, given_name, middle_name, family_name, suffix, title,
+    company_name, print_on_check_name, email, phone, mobile, fax, website,
+    bill_address, acct_num, vendor_1099, tax_identifier, term_ref, bill_rate,
+    active, draft = true,
+  } = args;
+
+  // Fetch current vendor
+  const current = await promisify<unknown>((cb) =>
+    (client as unknown as Record<string, Function>).getVendor(id, cb)
+  ) as QBVendor;
+
+  // Build sparse update
+  const updated: Record<string, unknown> = {
+    Id: current.Id,
+    SyncToken: current.SyncToken,
+    sparse: true,
+  };
+
+  if (display_name !== undefined) updated.DisplayName = display_name;
+  if (given_name !== undefined) updated.GivenName = given_name;
+  if (middle_name !== undefined) updated.MiddleName = middle_name;
+  if (family_name !== undefined) updated.FamilyName = family_name;
+  if (suffix !== undefined) updated.Suffix = suffix;
+  if (title !== undefined) updated.Title = title;
+  if (company_name !== undefined) updated.CompanyName = company_name;
+  if (print_on_check_name !== undefined) updated.PrintOnCheckName = print_on_check_name;
+  if (email !== undefined) updated.PrimaryEmailAddr = { Address: email };
+  if (phone !== undefined) updated.PrimaryPhone = { FreeFormNumber: phone };
+  if (mobile !== undefined) updated.Mobile = { FreeFormNumber: mobile };
+  if (fax !== undefined) updated.Fax = { FreeFormNumber: fax };
+  if (website !== undefined) updated.WebAddr = { URI: website };
+  if (bill_address !== undefined) updated.BillAddr = buildQBAddress(bill_address);
+  if (acct_num !== undefined) updated.AcctNum = acct_num;
+  if (vendor_1099 !== undefined) updated.Vendor1099 = vendor_1099;
+  if (tax_identifier !== undefined) updated.TaxIdentifier = tax_identifier;
+  if (bill_rate !== undefined) updated.BillRate = bill_rate;
+  if (active !== undefined) updated.Active = active;
+
+  // Resolve payment terms if provided
+  if (term_ref !== undefined) {
+    const terms = await promisify<{ QueryResponse: { Term?: Array<{ Id: string; Name: string }> } }>((cb) =>
+      (client as unknown as Record<string, Function>).findTerms(cb)
+    );
+    const termList = terms.QueryResponse?.Term || [];
+    const match = termList.find(t =>
+      t.Name.toLowerCase() === term_ref.toLowerCase() ||
+      t.Id === term_ref
+    );
+    if (!match) {
+      const available = termList.map(t => t.Name).join(', ');
+      throw new Error(`Term not found: "${term_ref}". Available: ${available}`);
+    }
+    updated.TermRef = { value: match.Id, name: match.Name };
+  }
+
+  const qboUrl = `https://app.qbo.intuit.com/app/vendordetail?nameId=${id}`;
+
+  if (draft) {
+    const previewLines: string[] = [
+      "DRAFT - Vendor Edit Preview",
+      "",
+      `ID: ${id}`,
+      `SyncToken: ${current.SyncToken}`,
+      "",
+      "Changes:",
+    ];
+
+    if (display_name !== undefined) previewLines.push(`  Display Name: ${current.DisplayName} → ${display_name}`);
+    if (given_name !== undefined) previewLines.push(`  Given Name: ${current.GivenName || "(none)"} → ${given_name}`);
+    if (middle_name !== undefined) previewLines.push(`  Middle Name: ${current.MiddleName || "(none)"} → ${middle_name}`);
+    if (family_name !== undefined) previewLines.push(`  Family Name: ${current.FamilyName || "(none)"} → ${family_name}`);
+    if (suffix !== undefined) previewLines.push(`  Suffix: ${current.Suffix || "(none)"} → ${suffix}`);
+    if (title !== undefined) previewLines.push(`  Title: ${current.Title || "(none)"} → ${title}`);
+    if (company_name !== undefined) previewLines.push(`  Company: ${current.CompanyName || "(none)"} → ${company_name}`);
+    if (print_on_check_name !== undefined) previewLines.push(`  Print on Check: ${current.PrintOnCheckName || "(none)"} → ${print_on_check_name}`);
+    if (email !== undefined) previewLines.push(`  Email: ${current.PrimaryEmailAddr?.Address || "(none)"} → ${email}`);
+    if (phone !== undefined) previewLines.push(`  Phone: ${current.PrimaryPhone?.FreeFormNumber || "(none)"} → ${phone}`);
+    if (mobile !== undefined) previewLines.push(`  Mobile: ${current.Mobile?.FreeFormNumber || "(none)"} → ${mobile}`);
+    if (fax !== undefined) previewLines.push(`  Fax: ${current.Fax?.FreeFormNumber || "(none)"} → ${fax}`);
+    if (website !== undefined) previewLines.push(`  Website: ${current.WebAddr?.URI || "(none)"} → ${website}`);
+    if (bill_address !== undefined) previewLines.push("  Address: (updating)");
+    if (acct_num !== undefined) previewLines.push(`  Account #: ${current.AcctNum || "(none)"} → ${acct_num}`);
+    if (vendor_1099 !== undefined) previewLines.push(`  1099 Vendor: ${current.Vendor1099 ?? false} → ${vendor_1099}`);
+    if (tax_identifier !== undefined) previewLines.push(`  Tax ID: (updating)`);
+    if (term_ref !== undefined) {
+      const newTerm = (updated.TermRef as { name?: string })?.name || term_ref;
+      previewLines.push(`  Terms: ${current.TermRef?.name || '(none)'} → ${newTerm}`);
+    }
+    if (bill_rate !== undefined) previewLines.push(`  Bill Rate: ${current.BillRate ?? "(none)"} → ${bill_rate}`);
+    if (active !== undefined) previewLines.push(`  Active: ${current.Active !== false} → ${active}`);
+
+    previewLines.push("");
+    previewLines.push("Set draft=false to apply these changes.");
+
+    return { content: [{ type: "text", text: previewLines.join("\n") }] };
+  }
+
+  const result = await promisify<unknown>((cb) =>
+    (client as unknown as Record<string, Function>).updateVendor(updated, cb)
+  ) as QBVendor;
+
+  return {
+    content: [{
+      type: "text",
+      text: `Vendor ${id} updated successfully.\nNew SyncToken: ${result.SyncToken}\nView in QuickBooks: ${qboUrl}`,
+    }],
+  };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -35,6 +35,9 @@ import {
   handleCreateCustomer,
   handleGetCustomer,
   handleEditCustomer,
+  handleCreateVendor,
+  handleGetVendor,
+  handleEditVendor,
   handleDeleteEntity,
   handleAuthenticate,
 } from "./handlers/index.js";
@@ -80,6 +83,9 @@ toolHandlers.set("edit_vendor_credit", (client, args) => handleEditVendorCredit(
 toolHandlers.set("create_customer", (client, args) => handleCreateCustomer(client, args as Parameters<typeof handleCreateCustomer>[1]));
 toolHandlers.set("get_customer", (client, args) => handleGetCustomer(client, args as { id: string }));
 toolHandlers.set("edit_customer", (client, args) => handleEditCustomer(client, args as Parameters<typeof handleEditCustomer>[1]));
+toolHandlers.set("create_vendor", (client, args) => handleCreateVendor(client, args as Parameters<typeof handleCreateVendor>[1]));
+toolHandlers.set("get_vendor", (client, args) => handleGetVendor(client, args as { id: string }));
+toolHandlers.set("edit_vendor", (client, args) => handleEditVendor(client, args as Parameters<typeof handleEditVendor>[1]));
 toolHandlers.set("delete_entity", (client, args) => handleDeleteEntity(client, args as Parameters<typeof handleDeleteEntity>[1]));
 
 // Execute tool with auth retry logic

--- a/src/types/node-quickbooks.d.ts
+++ b/src/types/node-quickbooks.d.ts
@@ -61,6 +61,7 @@ declare module "node-quickbooks" {
     createSalesReceipt(salesReceipt: object, callback: Callback<unknown>): void;
     createInvoice(invoice: object, callback: Callback<unknown>): void;
     createCustomer(customer: object, callback: Callback<unknown>): void;
+    createVendor(vendor: object, callback: Callback<unknown>): void;
     createVendorCredit(vendorCredit: object, callback: Callback<unknown>): void;
 
     // Get methods (single entity by ID)
@@ -71,6 +72,7 @@ declare module "node-quickbooks" {
     getInvoice(id: string, callback: Callback<unknown>): void;
     getDeposit(id: string, callback: Callback<unknown>): void;
     getCustomer(id: string, callback: Callback<unknown>): void;
+    getVendor(id: string, callback: Callback<unknown>): void;
     getVendorCredit(id: string, callback: Callback<unknown>): void;
 
     // Update methods
@@ -81,6 +83,7 @@ declare module "node-quickbooks" {
     updateInvoice(invoice: object, callback: Callback<unknown>): void;
     updateDeposit(deposit: object, callback: Callback<unknown>): void;
     updateCustomer(customer: object, callback: Callback<unknown>): void;
+    updateVendor(vendor: object, callback: Callback<unknown>): void;
     updateVendorCredit(vendorCredit: object, callback: Callback<unknown>): void;
 
     // Delete methods


### PR DESCRIPTION
## Summary

Adds vendor entity management tools following the existing customer handler pattern:

- **`create_vendor`**: Create vendors with display name, contact info, address, 1099 status, tax identifier (SSN/EIN), payment terms, and draft preview mode
- **`get_vendor`**: Fetch full vendor details by ID including SyncToken (tax ID returned masked per QBO API behavior)
- **`edit_vendor`**: Sparse updates for any vendor field, including deactivation via `active=false` (vendors cannot be deleted in QuickBooks)

All three tools support:
- Draft/preview mode (default: true), consistent with all other write tools
- Automatic name resolution for payment terms via `term_ref`
- Formatted text output with QBO deep links

## Why

The server has full Customer CRUD but no Vendor CRUD. Vendors are a core entity for anyone doing bookkeeping (bills, expenses, 1099 tracking, vendor audits). Today the only way to interact with vendors is querying them via `SELECT * FROM Vendor`, but you can't create, edit, or deactivate them.

The `node-quickbooks` library already has `createVendor`, `getVendor`, and `updateVendor` methods, so no new dependencies are needed.

## Changes

- `src/tools/handlers/vendor.ts` (new): Handler implementations
- `src/tools/handlers/index.ts`: Barrel export
- `src/tools/index.ts`: Handler registration
- `src/tools/definitions.ts`: Tool schemas
- `src/types/node-quickbooks.d.ts`: Type declarations for vendor methods
- `README.md`: Available Tools table updated

## Testing

Tested against production QBO with vendor queries. The handler follows the exact same patterns as `customer.ts` (address building, term resolution, sparse updates, draft previews).