### PR TITLE
fix: handle lines parameter arriving as JSON string in journal entry handlers

### DIFF
--- a/src/tools/handlers/journal-entry.ts
+++ b/src/tools/handlers/journal-entry.ts
@@ -45,7 +45,10 @@ export async function handleCreateJournalEntry(
     doc_number?: string;
   }
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
-  const { txn_date, memo, lines, draft = true, doc_number } = args;
+  const { txn_date, memo, lines: rawLines, draft = true, doc_number } = args;
+
+  // Defensive: MCP transports may deliver arrays as JSON strings
+  const lines: JournalEntryLine[] = typeof rawLines === "string" ? JSON.parse(rawLines) : rawLines;
 
   // Get cached accounts and departments (uses TTL-based cache)
   const [acctCache, deptCache] = await Promise.all([
@@ -294,7 +297,11 @@ export async function handleEditJournalEntry(
     draft?: boolean;
   }
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
-  const { id, txn_date, memo, doc_number, lines: lineChanges, draft = true } = args;
+  const { id, txn_date, memo, doc_number, lines: rawLineChanges, draft = true } = args;
+
+  // Defensive: MCP transports may deliver arrays as JSON strings
+  const lineChanges: JournalEntryLineChange[] | undefined =
+    typeof rawLineChanges === "string" ? JSON.parse(rawLineChanges) : rawLineChanges;
 
   // Fetch current JE
   const current = await promisify<unknown>((cb) =>


### PR DESCRIPTION
## Summary

- Add defensive `JSON.parse` for the `lines` parameter in both `handleCreateJournalEntry` and `handleEditJournalEntry` when it arrives as a string instead of a native array
- Some MCP transports (e.g., mcp-proxy, streamable HTTP) serialize array parameters as JSON strings, causing `lines.map is not a function` at runtime

## Problem

When `create_journal_entry` or `edit_journal_entry` is called through certain MCP transports, the `lines` array parameter is delivered as a serialized JSON string (`"[{...}]"`) rather than a parsed array. This causes the handler to crash with:

```
Error: lines.map is not a function
```

## Fix

Added a one-line defensive check in both handlers:

```typescript
const lines = typeof rawLines === "string" ? JSON.parse(rawLines) : rawLines;
```

This handles both cases transparently — native arrays pass through unchanged, JSON strings get parsed.

## Test plan

- [x] Builds cleanly (`npm run build`)
- [ ] Call `create_journal_entry` with `lines` as a native array — works as before
- [ ] Call `create_journal_entry` with `lines` as a JSON string — now works instead of crashing
- [ ] Same for `edit_journal_entry`