### PR TITLE
v0.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quickbooks-mcp",
-  "version": "0.5.0",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quickbooks-mcp",
-      "version": "0.5.0",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.700.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quickbooks-mcp",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "MCP server for QuickBooks Online API integration",
   "license": "MIT",
   "mcpName": "io.github.laf-rge/quickbooks-mcp",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/laf-rge/quickbooks-mcp",
     "source": "github"
   },
-  "version": "0.5.1",
+  "version": "0.5.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "quickbooks-mcp",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Release v0.5.2

Patch version bump for the MCP/npm release.

### Changes since v0.5.1
- fix(journal-entry): handle `lines` parameter arriving as JSON string (#20)
- Short-circuit warmer payloads in Lambda handler
- docs: document branch-and-PR workflow for master

### Files
- `package.json`, `package-lock.json` → 0.5.2
- `server.json` → 0.5.2 (top-level + `packages[0]`)

### Verification
- `npm run build` (tsc) ✅ exit 0
- `npm run build:lambda` (esbuild bundle) ✅ exit 0, handler.mjs ~2.4 MB

After merge: tag `v0.5.2` on master, then `npm publish` + `mcp-publisher publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)