### PR TITLE
feat(bill): support per-line ClassRef on create_bill and edit_bill

### DIFF
--- a/src/client/cache.ts
+++ b/src/client/cache.ts
@@ -5,10 +5,12 @@ import { promisify } from "./promisify.js";
 import {
   CachedAccount,
   CachedCustomer,
+  CachedClass,
   CachedDepartment,
   CachedVendor,
   CachedItem,
   AccountCache,
+  ClassCache,
   DepartmentCache,
   VendorCache,
   QBQueryResponse,
@@ -19,6 +21,7 @@ const LOOKUP_CACHE_TTL_MS = 15 * 60 * 1000;
 
 // Module-level cache state
 let departmentCache: DepartmentCache | null = null;
+let classCache: ClassCache | null = null;
 let accountCache: AccountCache | null = null;
 let vendorCache: VendorCache | null = null;
 // Item cache: lazy per-entry lookup (not bulk-loaded like others)
@@ -30,6 +33,7 @@ const customerCacheByName = new Map<string, CachedCustomer>(); // lowercase key
 
 export function clearLookupCache(): void {
   departmentCache = null;
+  classCache = null;
   accountCache = null;
   vendorCache = null;
   itemCacheById.clear();
@@ -62,6 +66,30 @@ export async function getDepartmentCache(client: QuickBooks): Promise<Department
 
   departmentCache = { items, byId, byName, fetchedAt: Date.now() };
   return departmentCache;
+}
+
+export async function getClassCache(client: QuickBooks): Promise<ClassCache> {
+  if (classCache && (Date.now() - classCache.fetchedAt) < LOOKUP_CACHE_TTL_MS) {
+    return classCache;
+  }
+
+  const result = await promisify<unknown>((cb) => client.findClasses({ fetchAll: true }, cb));
+  const items = extractQueryResults<CachedClass>(result, 'Class');
+
+  const byId = new Map<string, CachedClass>();
+  const byName = new Map<string, CachedClass>();
+  for (const cls of items) {
+    byId.set(cls.Id, cls);
+    // Index by both the leaf Name and the FullyQualifiedName ("Parent:Child") so
+    // nested classes resolve by either form.
+    byName.set(cls.Name.toLowerCase(), cls);
+    if (cls.FullyQualifiedName) {
+      byName.set(cls.FullyQualifiedName.toLowerCase(), cls);
+    }
+  }
+
+  classCache = { items, byId, byName, fetchedAt: Date.now() };
+  return classCache;
 }
 
 export async function getAccountCache(client: QuickBooks): Promise<AccountCache> {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -10,6 +10,7 @@ export {
 export {
   clearLookupCache,
   getDepartmentCache,
+  getClassCache,
   getAccountCache,
   getVendorCache,
   resolveAccount,

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -388,7 +388,7 @@ export const toolDefinitions = [
         },
         lines: {
           type: "array",
-          description: "Array of expense line items. Provide account_name OR account_id (name preferred).",
+          description: "Array of expense line items. Provide account_name OR account_id (name preferred). Optionally provide class_name OR class_id for per-line Class tracking.",
           items: {
             type: "object",
             properties: {
@@ -407,6 +407,14 @@ export const toolDefinitions = [
               description: {
                 type: "string",
                 description: "Line description (optional)",
+              },
+              class_name: {
+                type: "string",
+                description: "Class name for this line (e.g., '5614', 'Parent:Child'). Will be looked up to get ID. QBO Class tracking, distinct from header-level Department/Location.",
+              },
+              class_id: {
+                type: "string",
+                description: "Class ID (use if you already know it, otherwise use class_name)",
               },
             },
             required: ["amount"],
@@ -489,6 +497,14 @@ export const toolDefinitions = [
               description: {
                 type: "string",
                 description: "Line description",
+              },
+              class_name: {
+                type: "string",
+                description: "Class name for this line (e.g., '5614'), auto-resolved to ID. Sets/changes per-line QBO Class tracking. Existing class is preserved if omitted.",
+              },
+              class_id: {
+                type: "string",
+                description: "Class ID (use if you already know it, otherwise use class_name)",
               },
               delete: {
                 type: "boolean",

--- a/src/tools/handlers/bill.ts
+++ b/src/tools/handlers/bill.ts
@@ -4,6 +4,7 @@ import QuickBooks from "node-quickbooks";
 import {
   promisify,
   getAccountCache,
+  getClassCache,
   getDepartmentCache,
   getVendorCache,
   resolveVendor,
@@ -15,6 +16,8 @@ interface CreateBillLine {
   account_name?: string;
   amount: number;
   description?: string;
+  class_id?: string;
+  class_name?: string;
 }
 
 interface BillLineChange {
@@ -22,6 +25,8 @@ interface BillLineChange {
   account_name?: string;
   amount?: number;
   description?: string;
+  class_id?: string;
+  class_name?: string;
   delete?: boolean;
 }
 
@@ -52,11 +57,25 @@ export async function handleCreateBill(
   }
 
   // Get cached lookups
-  const [acctCache, deptCache, vendorCacheData] = await Promise.all([
+  const [acctCache, deptCache, vendorCacheData, classCacheData] = await Promise.all([
     getAccountCache(client),
     getDepartmentCache(client),
     getVendorCache(client),
+    getClassCache(client),
   ]);
+
+  // Resolve a class (location/Class tracking) by id or name to a QBO ClassRef.
+  const resolveClassRef = (nameOrId: string): { value: string; name: string } => {
+    const byId = classCacheData.byId.get(nameOrId);
+    if (byId) return { value: byId.Id, name: byId.FullyQualifiedName || byId.Name };
+    const byName = classCacheData.byName.get(nameOrId.toLowerCase());
+    if (byName) return { value: byName.Id, name: byName.FullyQualifiedName || byName.Name };
+    const byPartial = classCacheData.items.find(c =>
+      (c.FullyQualifiedName || c.Name).toLowerCase().includes(nameOrId.toLowerCase())
+    );
+    if (byPartial) return { value: byPartial.Id, name: byPartial.FullyQualifiedName || byPartial.Name };
+    throw new Error(`Class not found: "${nameOrId}"`);
+  };
 
   // Resolve vendor
   const resolveVendorRef = (nameOrId: string): { value: string; name: string } => {
@@ -164,18 +183,23 @@ export async function handleCreateBill(
     ...(doc_number && { DocNumber: doc_number }),
     ...(departmentRef && { DepartmentRef: departmentRef }),
     ...(apAccountRef && { APAccountRef: apAccountRef }),
-    Line: resolvedLines.map((line) => ({
-      Amount: line.amount,
-      DetailType: "AccountBasedExpenseLineDetail",
-      ...(line.description && { Description: line.description }),
-      AccountBasedExpenseLineDetail: {
-        AccountRef: {
-          value: line.account_id,
-          name: line.account_name,
+    Line: resolvedLines.map((line) => {
+      const classInput = line.class_id || line.class_name;
+      const classRef = classInput ? resolveClassRef(classInput) : undefined;
+      return {
+        Amount: line.amount,
+        DetailType: "AccountBasedExpenseLineDetail",
+        ...(line.description && { Description: line.description }),
+        AccountBasedExpenseLineDetail: {
+          AccountRef: {
+            value: line.account_id,
+            name: line.account_name,
+          },
+          BillableStatus: "NotBillable",
+          ...(classRef && { ClassRef: classRef }),
         },
-        BillableStatus: "NotBillable",
-      },
-    })),
+      };
+    }),
   };
 
   if (draft) {
@@ -404,7 +428,10 @@ export async function handleEditBill(
   let finalLines = [...((updated.Line as typeof current.Line) || current.Line)];
 
   if (lineChanges && lineChanges.length > 0) {
-    const acctCache = await getAccountCache(client);
+    const [acctCache, classCacheData] = await Promise.all([
+      getAccountCache(client),
+      getClassCache(client),
+    ]);
 
     const resolveAcct = (name: string) => {
       let match = acctCache.byAcctNum.get(name.toLowerCase());
@@ -414,6 +441,18 @@ export async function handleEditBill(
       );
       if (!match) throw new Error(`Account not found: "${name}"`);
       return { value: match.Id, name: match.FullyQualifiedName || match.Name };
+    };
+
+    const resolveClassRef = (nameOrId: string) => {
+      const byId = classCacheData.byId.get(nameOrId);
+      if (byId) return { value: byId.Id, name: byId.FullyQualifiedName || byId.Name };
+      const byName = classCacheData.byName.get(nameOrId.toLowerCase());
+      if (byName) return { value: byName.Id, name: byName.FullyQualifiedName || byName.Name };
+      const byPartial = classCacheData.items.find(c =>
+        (c.FullyQualifiedName || c.Name).toLowerCase().includes(nameOrId.toLowerCase())
+      );
+      if (byPartial) return { value: byPartial.Id, name: byPartial.FullyQualifiedName || byPartial.Name };
+      throw new Error(`Class not found: "${nameOrId}"`);
     };
 
     for (const change of lineChanges) {
@@ -430,6 +469,7 @@ export async function handleEditBill(
           const detail = { ...(line.AccountBasedExpenseLineDetail || {}) } as {
             AccountRef: { value: string; name?: string };
             DepartmentRef?: { value: string; name?: string };
+            ClassRef?: { value: string; name?: string };
           };
 
           if (change.amount !== undefined) {
@@ -438,6 +478,8 @@ export async function handleEditBill(
           }
           if (change.description !== undefined) line.Description = change.description;
           if (change.account_name !== undefined) detail.AccountRef = resolveAcct(change.account_name);
+          const classInput = change.class_id ?? change.class_name;
+          if (classInput !== undefined) detail.ClassRef = resolveClassRef(classInput);
 
           line.AccountBasedExpenseLineDetail = detail;
           line.DetailType = 'AccountBasedExpenseLineDetail';
@@ -452,12 +494,14 @@ export async function handleEditBill(
         const amountCents = validateAmount(change.amount, `New line for ${change.account_name}`);
 
         // Id omitted for new lines - QB will assign
+        const newClassInput = change.class_id ?? change.class_name;
         const newLine = {
           Amount: toDollars(amountCents),
           Description: change.description,
           DetailType: 'AccountBasedExpenseLineDetail',
           AccountBasedExpenseLineDetail: {
             AccountRef: resolveAcct(change.account_name),
+            ...(newClassInput !== undefined && { ClassRef: resolveClassRef(newClassInput) }),
           }
         } as typeof finalLines[0];
         finalLines.push(newLine);

--- a/src/types/cache.ts
+++ b/src/types/cache.ts
@@ -23,6 +23,19 @@ export interface DepartmentCache {
   fetchedAt: number;
 }
 
+export interface CachedClass {
+  Id: string;
+  Name: string;
+  FullyQualifiedName?: string;
+}
+
+export interface ClassCache {
+  items: CachedClass[];
+  byId: Map<string, CachedClass>;
+  byName: Map<string, CachedClass>;       // lowercase key (Name and FullyQualifiedName)
+  fetchedAt: number;
+}
+
 export interface AccountCache {
   items: CachedAccount[];
   byId: Map<string, CachedAccount>;


### PR DESCRIPTION
Closes #11 (for the bill surface).

## Problem

QBO bills support a per-line **Class** (`ClassRef`), distinct from the header-level **Location/Department** (`DepartmentRef`). The bill tools exposed `account_name`/`account_id` and `department_name` on line items but no way to set a Class, so any bill posted via the MCP was missing its Class — leaving incomplete GL entries to correct by hand. As #11 notes, customers using Class tracking (rather than Location) are the common case.

`edit_bill` already *preserved* an existing line's `ClassRef` on edits (it spreads the current detail), but there was no way to *set* one, and any **new** line it added was always classless.

## Change

- Add a Class lookup cache (`getClassCache` → `findClasses`) mirroring the department cache, indexed by `Id` and by `Name`/`FullyQualifiedName` (so `5614` or `Parent:Child` both resolve).
- `create_bill`: resolve `class_name`/`class_id` per line → `ClassRef`.
- `edit_bill`: set `ClassRef` on existing lines and carry it onto newly-added lines; an existing class is preserved when omitted.
- `definitions.ts`: add `class_name`/`class_id` to the `create_bill` and `edit_bill` line-item schemas (`edit_expense` left unchanged).

Builds clean (`tsc`). Verified end-to-end against a live production company: `create_bill` set the line's Class; an `edit_bill` that appended a new line gave it the Class; the existing line's Class was preserved — all confirmed by re-fetch.

Happy to extend the same pattern to invoices/purchases in a follow-up if you'd like it in one place.