### PR TITLE
feat(account-transactions): paginate instead of dead-ending at a cap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,14 @@ When building the `reportData` object passed to `outputReport()`, ask: **does th
 - **Yes**: Structured summaries, metadata, entity objects needed for follow-up edits (SyncToken, line IDs)
 - **No**: Raw API responses, full transaction lists for summary-only tools, redundant data the summary already covers
 
-For tools that return large datasets, cap the detail for HTTP mode using `isHttpMode()` from `src/utils/output.ts`. Compute summaries from the full data, then truncate the detail. See `account-transactions.ts` (`HTTP_TXN_LIMIT`) for the pattern.
+For tools that return large datasets, cap the detail for HTTP mode using `isHttpMode()` from `src/utils/output.ts`. Compute summaries from the full data, then window the detail. See `account-transactions.ts` (`HTTP_DEFAULT_LIMIT`) for the pattern.
+
+A cap alone is a dead end — the remote caller has no filesystem and cannot reach the rest. Pair it with a way out:
+
+- Window on whole records, not lines, so a page boundary can't split a transaction.
+- Default the window by transport: bounded in HTTP, full result set in stdio (the temp file is free).
+- Report the position back (`pagination.nextOffset`) **and** say so in the summary text — `query` emits `STARTPOSITION`, `query_account_transactions` emits `offset=`. A truncation notice with no continuation hint is a bug.
+- Keep totals computed over the full set so they never change as the caller pages.
 
 ## Common Files
 

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ QBO_INLINE_OUTPUT=true
 | `get_profit_loss` | Profit & Loss report (by month, department, class, etc.) |
 | `get_balance_sheet` | Balance Sheet report |
 | `get_trial_balance` | Trial Balance report |
-| `query_account_transactions` | All transactions affecting a specific account (13 posting entity types; see `docs/entity-coverage.md` for limits) |
+| `query_account_transactions` | All transactions affecting a specific account (13 posting entity types, paginated; see `docs/entity-coverage.md` for limits) |
 | `account_period_summary` | Period summary for an account (opening/closing balance, debits, credits, count) |
 | **Journal Entries** | |
 | `create_journal_entry` | Create a journal entry (validates debits = credits) |

--- a/docs/entity-coverage.md
+++ b/docs/entity-coverage.md
@@ -95,9 +95,29 @@ is the correct long-term fix for this whole class of gap.
 | Estimate, PurchaseOrder, TimeActivity | ❌ | non-posting by design |
 | RecurringTransaction | ❌ | template, not a transaction |
 
-Every call reports `coverage.scannedEntityTypes` in its report data, and warns
-in the summary when an individual entity query failed, so an incomplete
-drill-down is never presented as a complete one.
+Every call reports `coverage.scannedEntityTypes` in its report data (stdio only —
+it is static, and inline in HTTP it would be pure context cost), and warns in the
+summary when an individual entity query failed, so an incomplete drill-down is
+never presented as a complete one.
+
+### Completeness vs. the returned window
+
+Two different things can make a result look short, and they should not be
+confused:
+
+| | Meaning | How to get the rest |
+|---|---|---|
+| **Pagination** | The period has more transactions than this window returned. | Call again with the reported `offset`. Totals in `summary` already cover the full period. |
+| **Coverage** | The posting exists but carries no account reference (A/R, sales tax) or its entity type is not scanned. | Not retrievable here at all — use `account_period_summary`. |
+
+`summary.totalDebits` / `totalCredits` / `netChange` and `transactionCount` are
+always computed over the **full** result set, never the returned window, so they
+do not shift as a caller pages. Only `transactions` and `groupedByTransaction`
+are windowed.
+
+The window defaults to the full result set in stdio (detail goes to a temp file,
+so it is free) and to `HTTP_DEFAULT_LIMIT` transactions in HTTP mode (detail goes
+inline into the model's context). Both honor an explicit `limit`.
 
 ### Known partial extractions
 

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -162,6 +162,14 @@ export const toolDefinitions = [
         department: {
           type: "string",
           description: "Filter to specific department/location (optional)"
+        },
+        offset: {
+          type: "number",
+          description: "Skip this many transactions (default: 0). Page through long results using the offset the previous call reports."
+        },
+        limit: {
+          type: "number",
+          description: "Max transactions returned in detail. Totals always cover the whole period regardless of this."
         }
       },
       required: ["account"]

--- a/src/tools/handlers/account-transactions.ts
+++ b/src/tools/handlers/account-transactions.ts
@@ -25,6 +25,12 @@ import { TransactionLine } from "../../types/index.js";
 // A/R has no ARAccountRef on Invoice, CreditMemo, or Payment, and sales tax
 // posts through TxnTaxDetail with no AccountRef. Those postings cannot be
 // recovered from entity JSON at all — see docs/entity-coverage.md.
+// Default window size in HTTP mode, in transactions. HTTP has no filesystem, so
+// the detail goes straight into the model's context and must be bounded; stdio
+// writes to a temp file and defaults to the full result set. Sized so a typical
+// page stays close to the inline payload the previous 100-line cap produced.
+const HTTP_DEFAULT_LIMIT = 50;
+
 const POSTING_ENTITIES: Array<{ type: string; finder: string }> = [
   { type: 'JournalEntry', finder: 'findJournalEntries' },
   { type: 'Purchase', finder: 'findPurchases' },
@@ -88,9 +94,18 @@ export async function handleQueryAccountTransactions(
     start_date?: string;
     end_date?: string;
     department?: string;
+    offset?: number;
+    limit?: number;
   }
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
-  const { account, start_date, end_date, department } = args;
+  const { account, start_date, end_date, department, offset = 0, limit } = args;
+
+  if (!Number.isInteger(offset) || offset < 0) {
+    throw new Error(`offset must be a non-negative integer, got ${offset}`);
+  }
+  if (limit !== undefined && (!Number.isInteger(limit) || limit < 1)) {
+    throw new Error(`limit must be a positive integer, got ${limit}`);
+  }
 
   // Resolve account using cache
   const resolvedAccount = await resolveAccount(client, account);
@@ -230,21 +245,22 @@ export async function handleQueryAccountTransactions(
     };
   }
 
-  // In HTTP mode, cap transaction detail to avoid context bloat.
-  // Summary is always computed from the full dataset.
-  const HTTP_TXN_LIMIT = 100;
-  const truncated = isHttpMode() && allLines.length > HTTP_TXN_LIMIT;
+  // Window over whole transactions, never lines, so a page boundary can't split
+  // a journal entry in half. Summary stats above are always computed from the
+  // full result set, so totals stay correct no matter which window is returned.
+  const totalTransactions = groupedTransactions.length;
+  const windowOffset = Math.min(offset, totalTransactions);
+  const windowLimit = limit ?? (isHttpMode() ? HTTP_DEFAULT_LIMIT : totalTransactions);
+  const windowTxns = groupedTransactions.slice(windowOffset, windowOffset + windowLimit);
+  const nextOffset = windowOffset + windowTxns.length;
+  const hasMore = nextOffset < totalTransactions;
 
-  const outputLines = truncated ? allLines.slice(0, HTTP_TXN_LIMIT) : allLines;
+  const windowKeys = new Set(windowTxns.map(t => `${t.type}:${t.txnId}`));
+  const outputLines = allLines.filter(l => windowKeys.has(`${l.type}:${l.txnId}`));
   const outputGrouped: typeof groupedByTransaction = {};
-  if (truncated) {
-    // Only include groups that have at least one line in the truncated set
-    const truncatedTxnKeys = new Set(outputLines.map(l => `${l.type}:${l.txnId}`));
-    for (const [key, value] of Object.entries(groupedByTransaction)) {
-      if (truncatedTxnKeys.has(key)) outputGrouped[key] = value;
-    }
-  } else {
-    Object.assign(outputGrouped, groupedByTransaction);
+  for (const txn of windowTxns) {
+    const key = `${txn.type}:${txn.txnId}`;
+    outputGrouped[key] = groupedByTransaction[key];
   }
 
   const reportData = {
@@ -277,9 +293,16 @@ export async function handleQueryAccountTransactions(
       ...(isHttpMode() ? {} : { scannedEntityTypes: POSTING_ENTITIES.map(e => e.type) }),
       ...(failedTypes.length > 0 ? { failedEntityTypes: failedTypes } : {}),
     },
+    pagination: {
+      offset: windowOffset,
+      limit: windowLimit,
+      returnedTransactions: windowTxns.length,
+      totalTransactions,
+      hasMore,
+      ...(hasMore ? { nextOffset } : {}),
+    },
     transactions: outputLines,
     groupedByTransaction: outputGrouped,
-    ...(truncated ? { truncatedAt: HTTP_TXN_LIMIT, totalLines: allLines.length } : {}),
   };
 
   // Build summary for display
@@ -299,8 +322,15 @@ export async function handleQueryAccountTransactions(
   summaryLines.push('');
   summaryLines.push(`Summary: ${groupedTransactions.length} transactions | Debits: ${formatCurrency(totalDebits)} | Credits: ${formatCurrency(totalCredits)} | Net: ${netChange >= 0 ? '' : '-'}${formatCurrency(netChange)}`);
 
-  if (truncated) {
-    summaryLines.push(`(Showing first ${HTTP_TXN_LIMIT} of ${allLines.length} transaction lines in detail)`);
+  if (windowTxns.length === 0 && windowOffset > 0) {
+    summaryLines.push(`No transactions at offset ${windowOffset} — the period has ${totalTransactions}.`);
+  } else if (windowTxns.length < totalTransactions) {
+    summaryLines.push(
+      `Showing transactions ${windowOffset + 1}-${nextOffset} of ${totalTransactions} in detail.`
+    );
+    if (hasMore) {
+      summaryLines.push(`To fetch more: call again with offset=${nextOffset}.`);
+    }
   }
 
   if (failedTypes.length > 0) {
@@ -318,12 +348,14 @@ export async function handleQueryAccountTransactions(
     );
   }
 
-  if (groupedTransactions.length > 0) {
+  // Preview the returned window, not the full set — otherwise every page of a
+  // paginated walk shows the same five transactions.
+  if (windowTxns.length > 0) {
     summaryLines.push('');
-    summaryLines.push('Recent (first 5 transactions):');
+    summaryLines.push(`Preview (first 5 of this page):`);
     summaryLines.push('');
 
-    for (const txn of groupedTransactions.slice(0, 5)) {
+    for (const txn of windowTxns.slice(0, 5)) {
       const docNum = txn.docNumber ? ` #${txn.docNumber}` : '';
       const dept = txn.department ? ` [${txn.department}]` : '';
 


### PR DESCRIPTION
Follow-up to #28. Closes the continuation gap that PR surfaced.

## Why

`query_account_transactions` capped HTTP detail at 100 transaction **lines** and offered no way to reach the rest. It had exactly four parameters — `account`, `start_date`, `end_date`, `department` — so a remote caller reconciling a busy account could only narrow the date range and re-query until each slice happened to fit.

`query` already handles this correctly: it caps at MAXRESULTS and then tells the agent *"To fetch more: Add STARTPOSITION 101 to query."* The wall has a door. The account drill-down had a wall with no door. This brings it in line.

This matters more remotely than locally, and for a structural reason rather than a stylistic one: stdio writes full detail to a temp file, so the filepath acts as a lazy-loading handle and the caller can always go get the rest. HTTP has no filesystem, so a cap is genuinely terminal.

## What changed

Optional `offset` and `limit`. Three choices worth calling out:

**The window is over whole transactions, not lines.** A page boundary can never split a journal entry across two calls. The old cap sliced the flat line list and could hand back half a JE.

**Defaults stay transport-dependent**, matching the `MAXRESULTS` convention already in the codebase (100 in HTTP, 1000 in stdio). stdio defaults to the full result set — detail goes to a temp file and costs nothing. HTTP defaults to `HTTP_DEFAULT_LIMIT = 50` transactions. 50 rather than the old 100 because **the unit changed from lines to transactions**, which average 2–3 lines each; keeping 100 would have roughly tripled the inline payload. Both transports honor an explicit `limit`.

**Totals are unchanged by paging.** `totalDebits`, `totalCredits`, `netChange`, and `transactionCount` are still computed over the full result set, never the window, so they don't drift as a caller pages through.

Fixes a preview bug in passing: the summary previewed the first five of the *full* set, so every page of a paginated walk would have shown the same five transactions. It now previews the returned window.

## Testing

`npm run build` and `npm run build:lambda` pass; `tsc --noEmit` clean. No test or lint scripts exist in this repo.

The windowing math is pure, so it was verified directly across eight edge cases — offset past end, exact multiples, limit exceeding total, empty period, last partial page:

```
stdio, no args, 340          n=340 hasMore=false | (no pagination notice)
http, no args, 340           n= 50 hasMore= true | Showing 1-50 of 340. next offset=50
http, page 2                 n= 50 hasMore= true | Showing 51-100 of 340. next offset=100
http, last partial page      n= 40 hasMore=false | Showing 301-340 of 340.
offset past end              n=  0 hasMore=false | No transactions at offset 340 — the period has 340.
empty period                 n=  0 hasMore=false | (no notice)
exact multiple, last page    n= 50 hasMore=false | Showing 51-100 of 100.
limit larger than total      n= 10 hasMore=false | (no notice)

full paginated walk covers 0..339 exactly once: true (6 pages, 340 items)
```

Not exercised against live QBO — same environment constraint as #28.

## Docs

- **`CLAUDE.md`** pointed at `HTTP_TXN_LIMIT`, which this PR removes. Updated, and extended with the rule this change embodies: a cap without a continuation hint is a bug, because the remote caller has no filesystem to fall back on. Also records the window-on-records and stable-totals conventions so the next large-dataset tool follows them.
- **`docs/entity-coverage.md`** gains a table separating *"short because paginated"* from *"short because structurally invisible"* (A/R, sales tax). Those are very different failure modes for someone checking whether an account ties out, and conflating them is how a reconciliation goes wrong.
- **`README.md`** tool row notes pagination.

## Context cost

Two short parameter descriptions added; the tool description itself is unchanged. `pagination` replaces the old `truncatedAt`/`totalLines` fields rather than adding to them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
