### PR TITLE
v0.6.0

### DIFF
--- a/.claude/commands/publish.md
+++ b/.claude/commands/publish.md
@@ -10,8 +10,11 @@ If no argument is provided, ask the user which bump type they want (patch, minor
 ### 1. Pre-flight checks
 
 - Verify the working directory is clean (`git status` shows no uncommitted changes). If there are uncommitted changes, stop and ask the user to commit or stash them first.
-- Verify you are on the `master` branch. Warn if not.
 - Verify `npm whoami` succeeds (user is logged into npm).
+- Start from an up-to-date master and branch off it — **this repo never commits directly to `master`**, releases included:
+  ```
+  git fetch origin && git switch -c chore/release-{new_version} origin/master
+  ```
 
 ### 2. Version bump
 
@@ -26,25 +29,37 @@ If no argument is provided, ask the user which bump type they want (patch, minor
 - Run `npm run build` and verify it completes without errors.
 - If the build fails, stop and show the errors. Do not proceed with publishing.
 
-### 4. Publish to npm
+### 4. Open the release PR
 
-npm publish requires passkey authentication via browser. Do NOT run `npm publish` directly — it will fail waiting for interactive auth.
-
-Instead:
-- Tell the user to run `npm publish` themselves in their terminal.
-- Wait for the user to confirm it succeeded before continuing.
-
-### 5. Commit and tag
-
-Only proceed after the user confirms npm publish succeeded.
+The version bump lands on master through review like any other change.
 
 - Stage `package.json`, `package-lock.json`, and `server.json`.
 - Commit with message: `v{new_version}`
-- Create a git tag: `v{new_version}`
+- Push the branch and open a PR titled `v{new_version}` summarizing what ships in the release.
+- **Stop here and wait for the user to merge.** Do not merge it yourself.
 
-### 6. Push to GitHub
+### 5. Publish to npm
 
-- Run `git push && git push --tags`.
+Only proceed after the release PR is merged. Switch back to master and pull first,
+so the published artifact matches the merged tree:
+
+```
+git switch master && git fetch origin && git pull
+```
+
+npm publish requires passkey authentication via browser. Do NOT run `npm publish`
+directly — it will fail waiting for interactive auth.
+
+- Tell the user to run `npm publish` themselves in their terminal.
+- Wait for the user to confirm it succeeded before continuing.
+
+### 6. Tag the release
+
+Only proceed after the user confirms npm publish succeeded. The tag goes on the
+merge commit, not on the release branch.
+
+- Create a git tag: `git tag v{new_version}`
+- Push it: `git push --tags`
 
 ### 7. Publish to MCP Registry
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quickbooks-mcp",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quickbooks-mcp",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.700.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quickbooks-mcp",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "MCP server for QuickBooks Online API integration",
   "license": "MIT",
   "mcpName": "io.github.laf-rge/quickbooks-mcp",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/laf-rge/quickbooks-mcp",
     "source": "github"
   },
-  "version": "0.5.2",
+  "version": "0.6.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "quickbooks-mcp",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Version bump for publication. Minor — two backward-compatible feature PRs since v0.5.2, no breaking changes to existing tool signatures or output.

## What ships

**#28 — read coverage.** node-quickbooks only wraps ~35 entities and keeps its generic CRUD helpers on the CommonJS `module` object, so six queryable entities were unreachable. `src/client/rest.ts` closes that, and `query` now reaches every queryable QBO entity with no allow-list to maintain. The account drill-down went from 7 to 13 posting entity types (adding BillPayment, VendorCredit, Transfer, CreditMemo, RefundReceipt, CreditCardPayment). `docs/entity-coverage.md` records what stays structurally invisible — the A/R side of Invoice/CreditMemo/Payment carries no `ARAccountRef` at all — so an empty result isn't mistaken for no activity.

**#29 — pagination.** `query_account_transactions` capped HTTP detail with no way to page past it. Adds `offset`/`limit`, windowed over whole transactions so a page boundary can't split a journal entry, with totals still computed over the full period.

## Version consistency

`package.json`, `package-lock.json`, and both `server.json` fields (top-level and `packages[0]`) are all at `0.6.0`. Verified programmatically — they've drifted before, and the MCP Registry rejects a mismatch.

## Release process fix

`.claude/commands/publish.md` told the runner to *"Verify you are on the `master` branch"* and commit the bump directly there. This repo never commits to master, releases included. The steps now branch off `origin/master`, open a PR, and stop for review. Two related corrections:

- **Tagging moved after the merge**, so the tag lands on the merge commit rather than on a branch that gets squashed away — a tag pointing at an orphaned commit is worse than no tag.
- **`npm publish` now runs from a freshly pulled master**, so the published artifact matches the merged tree rather than the pre-merge branch.

## After merge

This PR only bumps the version. Remaining steps are yours (both need interactive auth):

1. `git switch master && git pull`
2. `npm publish` — passkey auth via browser
3. `git tag v0.6.0 && git push --tags`
4. `mcp-publisher publish`

## Not included

`ResponseFormat` was evaluated and **deliberately skipped** — measurement didn't support it. See the PR discussion; short version is that a real 4-line Bill is ~626 tokens of inline JSON, an explicit concise/detailed param would cost ~240 tokens of always-loaded description across the get_* tools to save ~340 per call, and the genuinely unbounded surfaces (`query`, `query_account_transactions`, reports) are already bounded by MAXRESULTS and the pagination in #29.

Neither PR has been exercised against live QBO — the dev environment blocks outbound API calls with real credentials. Both are verified by build, typecheck, and (for the pagination math) direct testing of the windowing across eight edge cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
