### PR TITLE
v0.6.1 — bound query concurrency and retry throttled requests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,13 @@ Both builds must pass before committing. After changes, restart Claude Code to r
   - Bill: `VendorRef`
   - Purchase (Expense): `PaymentType`
 - Department/Location filtering must be done client-side (not in QB queries)
+- Intuit throttles per realm. Fan out queries with `mapWithConcurrency` (not a
+  bare `Promise.all`) and let `withRetry` in `src/client/throttle.ts` handle
+  429/5xx — a throttled query returns empty, which silently reads as "no data"
+- **Parent vs. sub-account**: report-based tools (`account_period_summary`) roll
+  sub-accounts up into the parent; entity-based tools (`query_account_transactions`)
+  match the exact account ID only. The two will disagree on any parent account —
+  that is the data model, not a bug
 - node-quickbooks only wraps ~35 entities; use `src/client/rest.ts` for the rest
 - Some postings have no account reference in the payload (A/R, sales tax) and are
   invisible to entity-based reads — see `docs/entity-coverage.md`

--- a/docs/entity-coverage.md
+++ b/docs/entity-coverage.md
@@ -100,6 +100,23 @@ it is static, and inline in HTTP it would be pure context cost), and warns in th
 summary when an individual entity query failed, so an incomplete drill-down is
 never presented as a complete one.
 
+### Throttling is a third way a result can look short
+
+Intuit throttles per realm. The drill-down queries 13 entity types and each one
+auto-paginates, so firing them all at once reliably trips the limit — and a
+throttled entity comes back empty, which reads as "no activity on this account"
+rather than "ask again". Two guards:
+
+- Entity queries run at `ENTITY_QUERY_CONCURRENCY` (4) at a time rather than all
+  at once.
+- `fetcherForEntity` wraps every page fetch in `withRetry`, which backs off with
+  jitter on 429/5xx and network errors. Validation faults (4xxx) and auth faults
+  (3xxx) are **not** retried — a malformed query fails identically every time,
+  and retrying it burns throttle budget the other queries need.
+
+If an entity still fails after retries, the summary names it explicitly. Treat
+that warning as "this result is incomplete", not as a cosmetic note.
+
 ### Completeness vs. the returned window
 
 Two different things can make a result look short, and they should not be

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quickbooks-mcp",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quickbooks-mcp",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.700.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quickbooks-mcp",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "MCP server for QuickBooks Online API integration",
   "license": "MIT",
   "mcpName": "io.github.laf-rge/quickbooks-mcp",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/laf-rge/quickbooks-mcp",
     "source": "github"
   },
-  "version": "0.6.0",
+  "version": "0.6.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "quickbooks-mcp",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -8,6 +8,7 @@ export {
   getCompanyIdValue,
 } from './auth.js';
 export { qboRequest, qboQuery } from './rest.js';
+export { withRetry, isRetryableError } from './throttle.js';
 export {
   clearLookupCache,
   getDepartmentCache,

--- a/src/client/rest.ts
+++ b/src/client/rest.ts
@@ -63,8 +63,11 @@ export async function qboRequest<T>(
     if (response.status === 401) {
       throw { Fault: { Error: [{ Message: "Unauthorized", code: "401" }], type: "AUTHENTICATION" } };
     }
-    throw new Error(
-      `QuickBooks request failed (HTTP ${response.status}): ${text.slice(0, ERROR_BODY_CHARS)}`
+    // Carry the status so isRetryableError can tell a throttle (429) from a
+    // permanent failure without parsing the message.
+    throw Object.assign(
+      new Error(`QuickBooks request failed (HTTP ${response.status}): ${text.slice(0, ERROR_BODY_CHARS)}`),
+      { status: response.status }
     );
   }
 

--- a/src/client/throttle.ts
+++ b/src/client/throttle.ts
@@ -1,0 +1,67 @@
+// Retry for transient QuickBooks failures.
+//
+// Intuit throttles per realm, and fanning several entity queries out at once is
+// enough to trip it. A throttled query used to surface as an entity that simply
+// returned nothing, which in an account drill-down reads as "no activity" rather
+// than "ask again" — so retry before giving up.
+
+import { isQBError, extractQBErrorInfo } from "../types/index.js";
+
+// Intuit throttles with 429 and sheds load with 5xx under concurrency.
+const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504]);
+
+const MAX_ATTEMPTS = 3;
+const BASE_DELAY_MS = 300;
+
+function statusOf(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  // rest.ts attaches `status`; node-quickbooks hands back the underlying axios
+  // error, which carries it on `response`.
+  const e = error as { status?: number; response?: { status?: number } };
+  return e.status ?? e.response?.status;
+}
+
+/**
+ * Whether another attempt could plausibly succeed. Validation faults are not
+ * retried — a malformed query fails identically every time, and retrying it
+ * just burns throttle budget the caller needs for the queries that can work.
+ */
+export function isRetryableError(error: unknown): boolean {
+  const status = statusOf(error);
+  if (status !== undefined) return RETRYABLE_STATUS.has(status);
+
+  if (isQBError(error)) {
+    const { code } = extractQBErrorInfo(error);
+    // 4xxx fault codes are validation problems: unqueryable field, bad entity,
+    // syntax error. 3xxx are auth, handled by the retry in tools/index.ts.
+    return !(code?.startsWith("4") || code?.startsWith("3"));
+  }
+
+  // Neither a status nor a Fault — a socket or DNS blip. Worth one more try.
+  return true;
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Run `fn`, retrying transient failures with exponential backoff. Rethrows the
+ * last error once attempts are exhausted, so callers still see a real failure.
+ */
+export async function withRetry<T>(fn: () => Promise<T>, maxAttempts = MAX_ATTEMPTS): Promise<T> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (attempt === maxAttempts || !isRetryableError(error)) throw error;
+      // Jitter so parallel queries that were throttled together don't all wake
+      // up at the same instant and trip the limit again.
+      const backoff = BASE_DELAY_MS * 2 ** (attempt - 1);
+      await sleep(backoff + Math.random() * BASE_DELAY_MS);
+    }
+  }
+
+  throw lastError;
+}

--- a/src/query/pagination.ts
+++ b/src/query/pagination.ts
@@ -4,6 +4,7 @@ import QuickBooks from "node-quickbooks";
 import { PaginationParams, PaginatedQueryResult, QBQueryResponse } from "../types/index.js";
 import { promisify } from "../client/promisify.js";
 import { qboQuery } from "../client/rest.js";
+import { withRetry } from "../client/throttle.js";
 import { isHttpMode } from "../utils/output.js";
 
 // Pagination constants
@@ -85,11 +86,13 @@ export function rawFetcher(client: QuickBooks, entity: string): QueryFetcher {
 }
 
 // Resolve the cheapest fetcher for an entity: the wrapper method when one
-// exists, raw REST otherwise.
+// exists, raw REST otherwise. Wrapped in retry so a throttled or dropped page
+// doesn't surface as an entity that quietly returned nothing.
 export function fetcherForEntity(client: QuickBooks, entity: string, finderMethod: keyof QuickBooks): QueryFetcher {
-  return typeof client[finderMethod] === "function"
+  const fetcher = typeof client[finderMethod] === "function"
     ? finderFetcher(client, finderMethod)
     : rawFetcher(client, entity);
+  return (criteria) => withRetry(() => fetcher(criteria));
 }
 
 // Paginated query fetcher

--- a/src/tools/handlers/account-transactions.ts
+++ b/src/tools/handlers/account-transactions.ts
@@ -6,10 +6,22 @@ import {
   getDepartmentCache,
   getAccountCache,
 } from "../../client/index.js";
-import { toCents, sumCents, toDollars, outputReport, isHttpMode } from "../../utils/index.js";
+import { toCents, sumCents, toDollars, outputReport, isHttpMode, mapWithConcurrency } from "../../utils/index.js";
 import { PaginationParams } from "../../types/index.js";
 import { paginatedQuery, fetcherForEntity, extractAccountLines } from "../../query/index.js";
 import { TransactionLine } from "../../types/index.js";
+
+// Default window size in HTTP mode, in transactions. HTTP has no filesystem, so
+// the detail goes straight into the model's context and must be bounded; stdio
+// writes to a temp file and defaults to the full result set. Sized so a typical
+// page stays close to the inline payload the previous 100-line cap produced.
+const HTTP_DEFAULT_LIMIT = 50;
+
+// Entity queries in flight at once. Intuit throttles per realm, and each of
+// these auto-paginates, so the real request count is higher than the entity
+// count. Low enough to stay under the limit, high enough that the drill-down
+// still completes promptly.
+const ENTITY_QUERY_CONCURRENCY = 4;
 
 // Every QBO entity that posts to an account and exposes the account as a
 // reference in its JSON. `finder` is the node-quickbooks wrapper method; where
@@ -25,12 +37,6 @@ import { TransactionLine } from "../../types/index.js";
 // A/R has no ARAccountRef on Invoice, CreditMemo, or Payment, and sales tax
 // posts through TxnTaxDetail with no AccountRef. Those postings cannot be
 // recovered from entity JSON at all — see docs/entity-coverage.md.
-// Default window size in HTTP mode, in transactions. HTTP has no filesystem, so
-// the detail goes straight into the model's context and must be bounded; stdio
-// writes to a temp file and defaults to the full result set. Sized so a typical
-// page stays close to the inline payload the previous 100-line cap produced.
-const HTTP_DEFAULT_LIMIT = 50;
-
 const POSTING_ENTITIES: Array<{ type: string; finder: string }> = [
   { type: 'JournalEntry', finder: 'findJournalEntries' },
   { type: 'Purchase', finder: 'findPurchases' },
@@ -151,9 +157,15 @@ export async function handleQueryAccountTransactions(
   // Build date filter for QB query
   const dateFilter = `TxnDate >= '${startDateResolved}' AND TxnDate <= '${endDateResolved}'`;
 
-  // Query all entity types in parallel
-  const queryResults = await Promise.all(
-    POSTING_ENTITIES.map(async ({ type, finder }) => {
+  // Query the entity types with bounded parallelism. Firing all 13 at once
+  // reliably trips Intuit's per-realm throttle, and a throttled entity comes
+  // back empty — which in a drill-down reads as "no activity on this account"
+  // rather than "ask again". Retry lives in the fetcher; this keeps us from
+  // needing it in the first place.
+  const queryResults = await mapWithConcurrency(
+    POSTING_ENTITIES,
+    ENTITY_QUERY_CONCURRENCY,
+    async ({ type, finder }) => {
       const pagination: PaginationParams = {
         maxResults: 10000,  // Use full SAFETY_LIMIT for account transaction queries
         startPosition: null, // Auto-paginate
@@ -169,7 +181,7 @@ export async function handleQueryAccountTransactions(
         // returning an incomplete drill-down.
         return { type, entities: [], failed: true };
       }
-    })
+    }
   );
 
   const failedTypes = queryResults.filter(r => r.failed).map(r => r.type);

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -1,0 +1,33 @@
+// Bounded parallelism for fan-out work.
+
+/**
+ * Like `Promise.all(items.map(fn))`, but with at most `limit` calls in flight.
+ * Results stay in input order.
+ *
+ * Rejections propagate, same as Promise.all — callers that need per-item
+ * failure handling should catch inside `fn`.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const index = cursor++;
+      if (index >= items.length) return;
+      results[index] = await fn(items[index], index);
+    }
+  };
+
+  const workers = Array.from(
+    { length: Math.max(1, Math.min(limit, items.length)) },
+    worker
+  );
+  await Promise.all(workers);
+
+  return results;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,3 +4,4 @@ export * from './urls.js';
 export * from './files.js';
 export * from './output.js';
 export * from './money.js';
+export * from './concurrency.js';


### PR DESCRIPTION
Found by finally exercising v0.6.0 against a live QBO company. Includes the version bump to 0.6.1, since it's a single-fix patch.

## The bug

`query_account_transactions` fired all 13 entity queries at once through `Promise.all`, and each one auto-paginates, so the real request count is higher still. Intuit throttles per realm and this reliably trips it.

Measured across four consecutive identical calls: **three had at least one entity query fail** — `CreditCardPayment` twice, `RefundReceipt` once — while the same queries run standalone succeed every time.

The failure mode is the dangerous part. A throttled entity returns empty, and an empty entity in an account drill-down reads as **"no activity on this account"** rather than "ask again". For a tool used to reconcile, that's a wrong answer that looks like a right one.

For fairness to the v0.5.x code: it had the same exposure with 7 entity types and swallowed it *silently*. #28 raised the fan-out to 13, making it more frequent, but also added the warning that made it visible. This fixes the cause.

## The fix

**Bound the fan-out.** `ENTITY_QUERY_CONCURRENCY = 4` via a new `mapWithConcurrency` helper, replacing the unbounded `Promise.all`.

**Retry what's worth retrying.** `fetcherForEntity` wraps every page fetch in `withRetry` — three attempts, exponential backoff, with jitter so queries throttled together don't all wake at the same instant and trip the limit again. It sits in the shared fetcher, so the `query` tool gets transient-failure resilience too.

**Classification is deliberately narrow:**

| Error | Retry? | Why |
|---|:--:|---|
| 429, 5xx | ✅ | Throttle / load shedding |
| Bare network error | ✅ | Socket or DNS blip |
| Fault 6xxx | ✅ | Business rule, may be transient |
| Fault 4xxx | ❌ | Validation — fails identically every time; retrying burns throttle budget the working queries need |
| Fault 3xxx | ❌ | Auth already has refresh-and-retry in `tools/index.ts` |

`rest.ts` now attaches the HTTP status to thrown errors so classification never parses message strings. node-quickbooks surfaces the underlying axios error, whose status sits on `response` — both shapes are handled.

## Testing

Builds and typecheck pass. The retry and concurrency logic is pure, so it was exercised directly against the **built output**:

```
ok   429 throttle (rest.ts)         retryable=true
ok   503 (rest.ts)                  retryable=true
ok   axios 429 (node-quickbooks)    retryable=true
ok   404 permanent                  retryable=false
ok   4000 query validation fault    retryable=false
ok   3200 auth fault                retryable=false
ok   6000 business-rule fault       retryable=true
ok   bare socket error              retryable=true
ok   retries transient then succeeds -> attempts=3
ok   gives up immediately on validation fault -> attempts=1
ok   peak concurrency=4 (cap 4)
ok   results ordered & complete (13)
```

## Also verified live (v0.6.0, before this fix)

Worth recording, since these were unverified when #28 and #29 merged:

- **The raw REST path works.** `SELECT * FROM CreditCardPayment` returns real records — a query that threw "Unknown entity type" before #28.
- **The response key really is `CreditCardPaymentTxn`**, and the dynamic key discovery handles it.
- **The entity really has no `DepartmentRef` and no `Line`**, matching the docs.
- **The failure warning earned its keep immediately** — it's what exposed this bug.

## Correction to #28's stated premise

#28's description claimed a credit card account showed dozens of GL transactions but zero through the drill-down *because the transaction types were outside the scan list*. That diagnosis was wrong.

The real cause is **parent vs. sub-account rollup**: `account_period_summary` uses the GL report, which rolls sub-accounts into the parent, while `query_account_transactions` matches the exact account ID. The parent had no direct postings; the activity was all in the sub-accounts.

The work in #28 stands — those six entity types genuinely were missing and genuinely do post — but the motivating example was misdiagnosed. `CLAUDE.md` now documents the parent/sub distinction, since the two tool families legitimately disagree on any parent account and that cost real debugging time.

## Follow-up (not in this PR)

`query_account_transactions` likely wants an `include_subaccounts` option so it can match `account_period_summary` on parent accounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
