### PR TITLE
v0.7.0 — include_subaccounts for query_account_transactions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,8 +141,9 @@ Both builds must pass before committing. After changes, restart Claude Code to r
   429/5xx — a throttled query returns empty, which silently reads as "no data"
 - **Parent vs. sub-account**: report-based tools (`account_period_summary`) roll
   sub-accounts up into the parent; entity-based tools (`query_account_transactions`)
-  match the exact account ID only. The two will disagree on any parent account —
-  that is the data model, not a bug
+  match the exact account ID only. Pass `include_subaccounts: true` to make them
+  agree. Walk the tree with `collectAccountTree` — QBO nests up to 5 deep, so
+  checking `ParentRef` one level is not enough
 - node-quickbooks only wraps ~35 entities; use `src/client/rest.ts` for the rest
 - Some postings have no account reference in the payload (A/R, sales tax) and are
   invisible to entity-based reads — see `docs/entity-coverage.md`

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ QBO_INLINE_OUTPUT=true
 | `get_profit_loss` | Profit & Loss report (by month, department, class, etc.) |
 | `get_balance_sheet` | Balance Sheet report |
 | `get_trial_balance` | Trial Balance report |
-| `query_account_transactions` | All transactions affecting a specific account (13 posting entity types, paginated; see `docs/entity-coverage.md` for limits) |
+| `query_account_transactions` | All transactions affecting a specific account (13 posting entity types, paginated, optional sub-account rollup; see `docs/entity-coverage.md` for limits) |
 | `account_period_summary` | Period summary for an account (opening/closing balance, debits, credits, count) |
 | **Journal Entries** | |
 | `create_journal_entry` | Create a journal entry (validates debits = credits) |

--- a/docs/entity-coverage.md
+++ b/docs/entity-coverage.md
@@ -100,6 +100,30 @@ it is static, and inline in HTTP it would be pure context cost), and warns in th
 summary when an individual entity query failed, so an incomplete drill-down is
 never presented as a complete one.
 
+### Parent accounts: the drill-down and the reports count differently
+
+This is the single most confusing disagreement between the two account tools,
+and it is the data model rather than a bug:
+
+| Tool | Backed by | Counts sub-accounts? |
+|---|---|---|
+| `account_period_summary` | General Ledger report | **Always** — rolled into the parent |
+| `query_account_transactions` | Entity reads matching `AccountRef` | Only with `include_subaccounts: true` |
+
+A parent account that holds no postings of its own — common when a card or loan
+is tracked through named sub-accounts — reports plenty of activity in
+`account_period_summary` and **zero** in the drill-down. Nothing is missing; the
+postings name the sub-account, and an entity read matches one `AccountRef`.
+
+`include_subaccounts` defaults to `false` so existing callers keep their current
+results. When the resolved account has children and they were not included, the
+summary says so and names them, so the discrepancy explains itself rather than
+looking like missing data.
+
+Sub-accounts are collected with `collectAccountTree`, which walks `ParentRef`
+transitively — QBO nests up to five levels, so checking one level down is not
+enough — and tolerates a cyclic `ParentRef` without hanging.
+
 ### Throttling is a third way a result can look short
 
 Intuit throttles per realm. The drill-down queries 13 entity types and each one

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quickbooks-mcp",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quickbooks-mcp",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.700.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quickbooks-mcp",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "MCP server for QuickBooks Online API integration",
   "license": "MIT",
   "mcpName": "io.github.laf-rge/quickbooks-mcp",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/laf-rge/quickbooks-mcp",
     "source": "github"
   },
-  "version": "0.6.1",
+  "version": "0.7.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "quickbooks-mcp",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/client/cache.ts
+++ b/src/client/cache.ts
@@ -273,3 +273,33 @@ export async function resolveCustomer(client: QuickBooks, nameOrId: string): Pro
 
   return { value: customer.Id, name: customer.DisplayName };
 }
+
+/**
+ * An account plus every account nested beneath it, by Id.
+ *
+ * Report-based tools (the General Ledger behind account_period_summary) roll
+ * sub-account activity up into the parent, while entity-based reads match a
+ * single AccountRef. Callers that want to agree with the reports need the whole
+ * subtree. QBO nests arbitrarily deep, so this walks rather than checking
+ * ParentRef one level down.
+ */
+export function collectAccountTree(cache: AccountCache, rootId: string): Set<string> {
+  const childrenByParent = new Map<string, string[]>();
+  for (const account of cache.items) {
+    const parentId = account.ParentRef?.value;
+    if (!parentId) continue;
+    const siblings = childrenByParent.get(parentId);
+    if (siblings) siblings.push(account.Id);
+    else childrenByParent.set(parentId, [account.Id]);
+  }
+
+  const ids = new Set<string>();
+  const pending = [rootId];
+  while (pending.length > 0) {
+    const id = pending.pop()!;
+    if (ids.has(id)) continue; // also guards against a cyclic ParentRef
+    ids.add(id);
+    for (const childId of childrenByParent.get(id) ?? []) pending.push(childId);
+  }
+  return ids;
+}

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -19,4 +19,5 @@ export {
   resolveItem,
   resolveCustomer,
   resolveDepartmentId,
+  collectAccountTree,
 } from './cache.js';

--- a/src/query/account-transactions.ts
+++ b/src/query/account-transactions.ts
@@ -23,7 +23,7 @@ function getAccountName(accountId: string, accountCache: AccountCache, refName?:
 export function extractAccountLines(
   entities: Array<Record<string, unknown>>,
   entityType: string,
-  targetAccountId: string,
+  targetAccountIds: ReadonlySet<string>,
   accountCache: AccountCache,
   departmentFilter?: string
 ): TransactionLine[] {
@@ -62,7 +62,7 @@ export function extractAccountLines(
 
           const accountRef = detail.AccountRef as AccountRef | undefined;
           const accountId = accountRef?.value || '';
-          const isMatching = accountId === targetAccountId;
+          const isMatching = targetAccountIds.has(accountId);
           if (isMatching) hasMatchingLine = true;
 
           const postingType = detail.PostingType as string;
@@ -97,7 +97,7 @@ export function extractAccountLines(
 
         if (headerAccountId && headerMatchesDept) {
           const totalAmt = entity.TotalAmt as number;
-          const isMatching = headerAccountId === targetAccountId;
+          const isMatching = targetAccountIds.has(headerAccountId);
           if (isMatching) hasMatchingLine = true;
 
           extractedLines.push({
@@ -125,7 +125,7 @@ export function extractAccountLines(
 
           const accountRef = detail.AccountRef as AccountRef | undefined;
           const accountId = accountRef?.value || '';
-          const isMatching = accountId === targetAccountId;
+          const isMatching = targetAccountIds.has(accountId);
           if (isMatching) hasMatchingLine = true;
 
           extractedLines.push({
@@ -155,7 +155,7 @@ export function extractAccountLines(
 
         if (headerAccountId && headerMatchesDept) {
           const totalAmt = entity.TotalAmt as number;
-          const isMatching = headerAccountId === targetAccountId;
+          const isMatching = targetAccountIds.has(headerAccountId);
           if (isMatching) hasMatchingLine = true;
 
           extractedLines.push({
@@ -183,7 +183,7 @@ export function extractAccountLines(
 
           const accountRef = detail.AccountRef as AccountRef | undefined;
           const accountId = accountRef?.value || '';
-          const isMatching = accountId === targetAccountId;
+          const isMatching = targetAccountIds.has(accountId);
           if (isMatching) hasMatchingLine = true;
 
           extractedLines.push({
@@ -213,7 +213,7 @@ export function extractAccountLines(
 
         if (headerAccountId && headerMatchesDept) {
           const totalAmt = entity.TotalAmt as number;
-          const isMatching = headerAccountId === targetAccountId;
+          const isMatching = targetAccountIds.has(headerAccountId);
           if (isMatching) hasMatchingLine = true;
 
           extractedLines.push({
@@ -244,7 +244,7 @@ export function extractAccountLines(
           const accountId = itemAccountRef?.value || '';
           if (!accountId) continue; // Skip lines without explicit account
 
-          const isMatching = accountId === targetAccountId;
+          const isMatching = targetAccountIds.has(accountId);
           if (isMatching) hasMatchingLine = true;
 
           // Get item name for description context
@@ -280,7 +280,7 @@ export function extractAccountLines(
 
         if (headerAccountId && headerMatchesDept) {
           const totalAmt = entity.TotalAmt as number;
-          const isMatching = headerAccountId === targetAccountId;
+          const isMatching = targetAccountIds.has(headerAccountId);
           if (isMatching) hasMatchingLine = true;
 
           extractedLines.push({
@@ -308,7 +308,7 @@ export function extractAccountLines(
 
           const accountRef = detail.AccountRef as AccountRef | undefined;
           const accountId = accountRef?.value || '';
-          const isMatching = accountId === targetAccountId;
+          const isMatching = targetAccountIds.has(accountId);
           if (isMatching) hasMatchingLine = true;
 
           extractedLines.push({
@@ -339,7 +339,7 @@ export function extractAccountLines(
         const invoiceMatchesDept = !departmentFilter || invoiceDeptRef?.value === departmentFilter;
 
         if (depositToRef?.value && depositAmt && invoiceMatchesDept) {
-          const isMatching = depositToRef.value === targetAccountId;
+          const isMatching = targetAccountIds.has(depositToRef.value);
           if (isMatching) hasMatchingLine = true;
 
           extractedLines.push({
@@ -366,7 +366,7 @@ export function extractAccountLines(
           const accountId = itemAccountRef?.value || '';
           if (!accountId) continue; // Skip lines without explicit account
 
-          const isMatching = accountId === targetAccountId;
+          const isMatching = targetAccountIds.has(accountId);
           if (isMatching) hasMatchingLine = true;
 
           // Get item name for description context
@@ -408,7 +408,7 @@ export function extractAccountLines(
 
           // A/P side: debit (paying a bill reduces what is owed)
           if (apRef?.value) {
-            const isMatching = apRef.value === targetAccountId;
+            const isMatching = targetAccountIds.has(apRef.value);
             if (isMatching) hasMatchingLine = true;
             extractedLines.push({
               date: txnDate, type: 'BillPayment', txnId, docNumber, lineId: 'header',
@@ -423,7 +423,7 @@ export function extractAccountLines(
 
           // Funding side: credit
           if (payRef?.value) {
-            const isMatching = payRef.value === targetAccountId;
+            const isMatching = targetAccountIds.has(payRef.value);
             if (isMatching) hasMatchingLine = true;
             extractedLines.push({
               date: txnDate, type: 'BillPayment', txnId, docNumber, lineId: 'payment',
@@ -448,7 +448,7 @@ export function extractAccountLines(
 
         if (headerAccountId && headerMatchesDept) {
           const totalAmt = entity.TotalAmt as number;
-          const isMatching = headerAccountId === targetAccountId;
+          const isMatching = targetAccountIds.has(headerAccountId);
           if (isMatching) hasMatchingLine = true;
 
           extractedLines.push({
@@ -471,7 +471,7 @@ export function extractAccountLines(
 
           const accountRef = detail.AccountRef as AccountRef | undefined;
           const accountId = accountRef?.value || '';
-          const isMatching = accountId === targetAccountId;
+          const isMatching = targetAccountIds.has(accountId);
           if (isMatching) hasMatchingLine = true;
 
           extractedLines.push({
@@ -500,7 +500,7 @@ export function extractAccountLines(
           [fromRef, -amount, 'from'],
         ] as Array<[AccountRef | undefined, number, string]>) {
           if (!ref?.value) continue;
-          const isMatching = ref.value === targetAccountId;
+          const isMatching = targetAccountIds.has(ref.value);
           if (isMatching) hasMatchingLine = true;
           extractedLines.push({
             date: txnDate, type: 'Transfer', txnId, docNumber, lineId,
@@ -528,7 +528,7 @@ export function extractAccountLines(
           [bankRef, -amount, 'bank'],
         ] as Array<[AccountRef | undefined, number, string]>) {
           if (!ref?.value) continue;
-          const isMatching = ref.value === targetAccountId;
+          const isMatching = targetAccountIds.has(ref.value);
           if (isMatching) hasMatchingLine = true;
           extractedLines.push({
             date: txnDate, type: 'CreditCardPayment', txnId, docNumber, lineId,
@@ -557,7 +557,7 @@ export function extractAccountLines(
           const accountId = itemAccountRef?.value || '';
           if (!accountId) continue;
 
-          const isMatching = accountId === targetAccountId;
+          const isMatching = targetAccountIds.has(accountId);
           if (isMatching) hasMatchingLine = true;
 
           const itemRef = detail.ItemRef as { name?: string } | undefined;
@@ -586,7 +586,7 @@ export function extractAccountLines(
 
         if (headerAccountId && headerMatchesDept) {
           const totalAmt = entity.TotalAmt as number;
-          const isMatching = headerAccountId === targetAccountId;
+          const isMatching = targetAccountIds.has(headerAccountId);
           if (isMatching) hasMatchingLine = true;
 
           extractedLines.push({
@@ -611,7 +611,7 @@ export function extractAccountLines(
           const accountId = itemAccountRef?.value || '';
           if (!accountId) continue;
 
-          const isMatching = accountId === targetAccountId;
+          const isMatching = targetAccountIds.has(accountId);
           if (isMatching) hasMatchingLine = true;
 
           const itemRef = detail.ItemRef as { name?: string } | undefined;
@@ -640,7 +640,7 @@ export function extractAccountLines(
 
         if (accountId && headerMatchesDept) {
           const totalAmt = entity.TotalAmt as number;
-          const isMatching = accountId === targetAccountId;
+          const isMatching = targetAccountIds.has(accountId);
           if (isMatching) hasMatchingLine = true;
 
           extractedLines.push({

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -170,6 +170,10 @@ export const toolDefinitions = [
         limit: {
           type: "number",
           description: "Max transactions returned in detail. Totals always cover the whole period regardless of this."
+        },
+        include_subaccounts: {
+          type: "boolean",
+          description: "Also match transactions posting to sub-accounts of this account (default: false). Needed to reconcile against account_period_summary, which always rolls sub-accounts into the parent."
         }
       },
       required: ["account"]

--- a/src/tools/handlers/account-transactions.ts
+++ b/src/tools/handlers/account-transactions.ts
@@ -5,6 +5,7 @@ import {
   resolveAccount,
   getDepartmentCache,
   getAccountCache,
+  collectAccountTree,
 } from "../../client/index.js";
 import { toCents, sumCents, toDollars, outputReport, isHttpMode, mapWithConcurrency } from "../../utils/index.js";
 import { PaginationParams } from "../../types/index.js";
@@ -102,9 +103,10 @@ export async function handleQueryAccountTransactions(
     department?: string;
     offset?: number;
     limit?: number;
+    include_subaccounts?: boolean;
   }
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
-  const { account, start_date, end_date, department, offset = 0, limit } = args;
+  const { account, start_date, end_date, department, offset = 0, limit, include_subaccounts = false } = args;
 
   if (!Number.isInteger(offset) || offset < 0) {
     throw new Error(`offset must be a non-negative integer, got ${offset}`);
@@ -118,6 +120,15 @@ export async function handleQueryAccountTransactions(
 
   // Get account cache for name lookups
   const accountCache = await getAccountCache(client);
+
+  // Which AccountRefs count as a hit. Entity reads match one account by default;
+  // opting in to sub-accounts makes this agree with account_period_summary,
+  // whose General Ledger report rolls the subtree into the parent.
+  const wholeTree = collectAccountTree(accountCache, resolvedAccount.Id);
+  const subAccountIds = [...wholeTree].filter(id => id !== resolvedAccount.Id);
+  const targetAccountIds: ReadonlySet<string> = include_subaccounts
+    ? wholeTree
+    : new Set([resolvedAccount.Id]);
 
   // Resolve department if provided using cache
   let resolvedDepartmentId: string | undefined;
@@ -192,7 +203,7 @@ export async function handleQueryAccountTransactions(
     const lines = extractAccountLines(
       entities,
       type,
-      resolvedAccount.Id,
+      targetAccountIds,
       accountCache,
       resolvedDepartmentId
     );
@@ -278,6 +289,7 @@ export async function handleQueryAccountTransactions(
   const reportData = {
     account: {
       id: resolvedAccount.Id,
+      includedSubAccountIds: include_subaccounts ? subAccountIds : [],
       acctNum: resolvedAccount.AcctNum,
       name: resolvedAccount.FullyQualifiedName || resolvedAccount.Name,
       type: resolvedAccount.AccountType,
@@ -329,6 +341,21 @@ export async function handleQueryAccountTransactions(
 
   if (resolvedDepartmentName) {
     summaryLines.push(`Department: ${resolvedDepartmentName}`);
+  }
+
+  // Say which accounts were actually matched. Without this, a parent account
+  // that holds no postings of its own looks empty while account_period_summary
+  // reports plenty — the single most confusing disagreement between the two.
+  if (subAccountIds.length > 0) {
+    const names = subAccountIds
+      .map(id => accountCache.byId.get(id))
+      .map(a => (a?.AcctNum ? `${a.AcctNum} ${a.Name}` : a?.Name))
+      .filter(Boolean);
+    summaryLines.push(
+      include_subaccounts
+        ? `Including ${subAccountIds.length} sub-account(s): ${names.join(', ')}`
+        : `Note: this account has ${subAccountIds.length} sub-account(s) — ${names.join(', ')} — whose transactions are NOT included. Pass include_subaccounts=true to include them (account_period_summary always rolls them up).`
+    );
   }
 
   summaryLines.push('');

--- a/src/types/cache.ts
+++ b/src/types/cache.ts
@@ -14,6 +14,10 @@ export interface CachedAccount {
   AccountType?: string;
   CurrentBalance?: number;
   Active?: boolean;
+  // QBO nests accounts arbitrarily deep; ParentRef is how the tree is walked.
+  SubAccount?: boolean;
+  ParentRef?: { value: string; name?: string };
+  CurrentBalanceWithSubAccounts?: number;
 }
 
 export interface DepartmentCache {


### PR DESCRIPTION
The follow-up flagged in #31. Includes the version bump, so one publish carries both this and 0.6.1.

## Why

`account_period_summary` and `query_account_transactions` legitimately disagree on any parent account, and nothing explained why:

| Tool | Backed by | Counts sub-accounts? |
|---|---|---|
| `account_period_summary` | General Ledger report | **Always** — rolled into the parent |
| `query_account_transactions` | Entity reads matching `AccountRef` | Only with `include_subaccounts: true` |

A parent account that holds no postings of its own — the normal shape when a card or loan is tracked through named sub-accounts — shows plenty of activity in one tool and **zero** in the other. Nothing is missing: the postings name the sub-account, and an entity read matches one `AccountRef`. This is exactly what I misdiagnosed as an entity-coverage gap back in #28.

## What changed

`include_subaccounts`, **defaulting to `false`** so existing callers keep their current results.

The more useful half is what happens when you *don't* pass it: if the resolved account has children and they weren't included, the summary now names them and says so explicitly. The discrepancy explains itself instead of looking like missing data — same principle as the throttle warning in #31 and the pagination hint in #29.

`collectAccountTree` walks `ParentRef` **transitively** rather than checking one level down. QBO nests up to five deep, so a sub-of-a-sub would otherwise be silently missed. It also tolerates a cyclic `ParentRef` without hanging. `ParentRef`/`SubAccount` were already in the cached Account payload — only the TypeScript type needed widening, no extra API calls.

`extractAccountLines` now takes a `ReadonlySet<string>` instead of a single id. That's what let this be a set-membership test rather than a special case threaded through all 13 entity branches.

## Versioning

**0.7.0, not 0.6.2** — this adds a tool parameter, which is a feature under semver. 0.6.1 merged but was never published, so this release carries both it and this change. All four version fields verified consistent.

## Testing

Builds and typecheck pass. `collectAccountTree` is pure, so it was exercised against the **built output**, using the real parent/child shape from a live chart of accounts:

```
ok   parent -> self + 3 children: [ '145', '305', '57', '58' ]
ok   leaf -> just itself: [ '57' ]
ok   no children -> just itself: [ '999' ]
ok   4 levels deep: [ 'a', 'b', 'c', 'd' ]
ok   mid-tree -> own subtree only: [ 'b', 'c', 'd' ]
ok   cycle terminates: [ 'x', 'y' ]
ok   unknown id -> still returns itself
```

Not exercised end-to-end against live QBO: the local MCP server runs from `master`'s build, so that has to wait until this merges. The behavior to confirm afterward is a parent credit-card account returning zero without the flag and its sub-accounts' transactions with it.

## After merge

```
git switch master && git pull
npm publish
git tag v0.7.0 && git push --tags
mcp-publisher publish
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
