### PR TITLE
fix(account-transactions): honor Purchase.Credit so refunds debit the account

### DIFF
--- a/docs/entity-coverage.md
+++ b/docs/entity-coverage.md
@@ -160,6 +160,16 @@ The window defaults to the full result set in stdio (detail goes to a temp file,
 so it is free) and to `HTTP_DEFAULT_LIMIT` transactions in HTTP mode (detail goes
 inline into the model's context). Both honor an explicit `limit`.
 
+### Refunds flip the sign
+
+`Purchase.Credit === true` marks a refund or return rather than a charge. Both
+sides invert: the bank or card is **debited** and the expense account credited.
+QBO's own reports honor this, so an extractor that ignores it counts a refund as
+a second charge and the account cannot tie out to the General Ledger.
+
+Only `Purchase` carries this flag. Refunds on the sales side are their own
+entity (`RefundReceipt`), already signed correctly.
+
 ### Known partial extractions
 
 Real gaps within entities that *are* scanned:

--- a/src/query/account-transactions.ts
+++ b/src/query/account-transactions.ts
@@ -89,7 +89,13 @@ export function extractAccountLines(
       }
 
       case 'purchase': {
-        // Header: AccountRef is the bank/credit card account being debited
+        // Purchase.Credit marks a refund or return: the money comes back, so
+        // every side of the transaction flips. QBO's own reports honor this —
+        // without it a refund is counted as a second charge and the account
+        // never ties out to the General Ledger.
+        const purchaseSign = entity.Credit === true ? -1 : 1;
+
+        // Header: AccountRef is the bank/credit card account being credited
         const headerAccountRef = entity.AccountRef as AccountRef | undefined;
         const headerAccountId = headerAccountRef?.value || '';
         const headerDeptRef = entity.DepartmentRef as { value?: string; name?: string } | undefined;
@@ -106,7 +112,7 @@ export function extractAccountLines(
             txnId,
             docNumber,
             lineId: 'header',
-            amount: -totalAmt, // Credit to bank account
+            amount: -totalAmt * purchaseSign, // Credit to bank account; debit when a refund
             description: entity.PrivateNote as string | undefined,
             department: headerDeptRef?.name,
             qboLink,
@@ -134,7 +140,7 @@ export function extractAccountLines(
             txnId,
             docNumber,
             lineId: line.Id as string,
-            amount: line.Amount as number, // Debit to expense account
+            amount: (line.Amount as number) * purchaseSign, // Debit to expense account; credit when a refund
             description: line.Description as string | undefined,
             department: getDepartment(detail),
             qboLink,


### PR DESCRIPTION
Found by reconciling the drill-down against the General Ledger for the first time — which only became possible once `include_subaccounts` (#32) let the two tools look at the same set of accounts.

## The bug

A `Purchase` with `Credit === true` is a **refund or return**, not a charge. Both sides invert: the bank or card is debited and the expense account credited. The extractor signed every Purchase as a charge, so a refund was counted as a second charge and the account could not tie out.

The evidence was clean. Comparing a parent card account for one month:

| | Debits | Credits |
|---|---|---|
| `account_period_summary` (GL report) | 32,111.27 | 31,595.96 |
| `query_account_transactions` | 32,049.94 | 31,657.29 |
| **delta** | **−61.33** | **+61.33** |

Off by the same amount in each direction — the signature of a sign error, not a missing transaction. The cause was a $61.33 Home Depot charge and its matching $61.33 refund, both recorded as credits. With the flag honored both sides land on the GL's figures **exactly**.

Also worth recording: the drill-down's 82 matching lines already equalled the GL's 82 rows. The "70 transactions" in the summary is the *grouped* count, so the two tools were never actually disagreeing on population — only on that one sign.

## Scope

**Pre-existing.** The `purchase` branch predates the recent read-coverage work; the bug was simply invisible until the drill-down could be compared against a report. Anyone who has used `query_account_transactions` on an account with refunds has had a wrong total.

Only `Purchase` carries this flag. Sales-side refunds are their own entity (`RefundReceipt`), already signed correctly.

## Version

Stays at **0.7.0** — merged but not yet published, so this ships with it rather than as a separate patch.

## Testing

Builds and typecheck pass. Verified against the built output:

```
ok   charge: card credited -61.33, expense debited 61.33
ok   refund: card DEBITED  61.33, expense credited -61.33
ok   expense side flips too
ok   charge+refund pair nets to $0.00 on the card
```

That last case is the real-world one: a purchase and its refund should leave the account exactly where it started.

## After merge

```
git switch master && git pull
npm publish
git tag v0.7.0 && git push --tags
mcp-publisher publish
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
