### PR TITLE
v0.7.1 — fix closing balance on rolled-up account_period_summary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quickbooks-mcp",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quickbooks-mcp",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.700.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quickbooks-mcp",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "MCP server for QuickBooks Online API integration",
   "license": "MIT",
   "mcpName": "io.github.laf-rge/quickbooks-mcp",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/laf-rge/quickbooks-mcp",
     "source": "github"
   },
-  "version": "0.7.0",
+  "version": "0.7.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "quickbooks-mcp",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/tools/handlers/account-period-summary.ts
+++ b/src/tools/handlers/account-period-summary.ts
@@ -4,7 +4,7 @@
 
 import QuickBooks from "node-quickbooks";
 import { resolveAccount, resolveDepartmentId, promisify } from "../../client/index.js";
-import { outputReport } from "../../utils/index.js";
+import { outputReport, toCents, toDollars } from "../../utils/index.js";
 import { QBReport } from "../../types/index.js";
 
 interface GLRowColData {
@@ -48,21 +48,30 @@ interface PeriodSummary {
  *
  * Columns: Date, Transaction Type, Num, Name, Memo/Description, Split, Amount, Balance
  * - "Amount" column: negative = debit, positive = credit
- * - "Balance" column: running balance (present on transaction rows, not on Summary)
- * - "Beginning Balance" row: Balance column has opening balance
+ * - "Balance" column: running balance, restarting at each section
+ * - "Beginning Balance" row: Balance column has that section's opening balance
  * - Summary row: Amount column has net activity total; Balance column is empty
- * - Closing balance: Balance column of the last transaction row
+ *
+ * A report for a parent account contains one section per account in the subtree,
+ * each with its own Beginning Balance and its own running Balance. Opening
+ * balances therefore sum across sections, but the running Balance column does
+ * NOT — the last row of the report is only the last *section's* closing figure.
+ * Closing is derived as opening + net activity, which is true per section and
+ * per rollup, rather than read from that column.
+ *
+ * Amounts accumulate in integer cents (see src/utils/money.ts) so a few hundred
+ * float additions cannot drift the totals.
  */
-function parseGLReport(report: GLReport): PeriodSummary {
+// Exported for verification: this is where the rollup arithmetic lives.
+export function parseGLReport(report: GLReport): PeriodSummary {
   const columns = report.Columns?.Column ?? [];
 
   const amountIdx = columns.findIndex(c => c.ColTitle === "Amount");
   const balanceIdx = columns.findIndex(c => c.ColTitle === "Balance");
 
-  let openingBalance = 0;
-  let closingBalance = 0;
-  let totalDebits = 0;
-  let totalCredits = 0;
+  let openingCents = 0;
+  let totalDebitsCents = 0;
+  let totalCreditsCents = 0;
   let transactionCount = 0;
 
   const rows = report.Rows?.Row ?? [];
@@ -80,8 +89,9 @@ function parseGLReport(report: GLReport): PeriodSummary {
         const firstCol = colData[0]?.value ?? "";
 
         if (firstCol === "Beginning Balance") {
+          // One per section; a rollup report has several, and they sum.
           if (balanceIdx >= 0 && colData[balanceIdx]?.value) {
-            openingBalance += parseFloat(colData[balanceIdx].value!) || 0;
+            openingCents += toCents(parseFloat(colData[balanceIdx].value!) || 0);
           }
           continue;
         }
@@ -94,15 +104,10 @@ function parseGLReport(report: GLReport): PeriodSummary {
         if (amount !== 0) {
           transactionCount++;
           if (amount < 0) {
-            totalDebits += Math.abs(amount);
+            totalDebitsCents += toCents(Math.abs(amount));
           } else {
-            totalCredits += amount;
+            totalCreditsCents += toCents(amount);
           }
-        }
-
-        // Track running balance — last row's balance = closing balance
-        if (balanceIdx >= 0 && colData[balanceIdx]?.value) {
-          closingBalance = parseFloat(colData[balanceIdx].value!) || 0;
         }
       }
     }
@@ -110,19 +115,16 @@ function parseGLReport(report: GLReport): PeriodSummary {
 
   processRows(rows);
 
-  // If no transactions, closing = opening
-  if (transactionCount === 0) {
-    closingBalance = openingBalance;
-  }
-
-  const netActivity = totalCredits - totalDebits;
+  const netActivityCents = totalCreditsCents - totalDebitsCents;
 
   return {
-    openingBalance,
-    closingBalance,
-    totalDebits,
-    totalCredits,
-    netActivity,
+    openingBalance: toDollars(openingCents),
+    // Derived, not read from the Balance column: that column restarts per
+    // section, so on a rollup its final value is just the last sub-account's.
+    closingBalance: toDollars(openingCents + netActivityCents),
+    totalDebits: toDollars(totalDebitsCents),
+    totalCredits: toDollars(totalCreditsCents),
+    netActivity: toDollars(netActivityCents),
     transactionCount,
   };
 }


### PR DESCRIPTION
The oddity spotted while reconciling #33. It's a real bug, and it only affects parent accounts.

## The bug

A General Ledger report for a parent account contains **one section per account in the subtree**, and the Balance column **restarts at each section**. The parser tracked it as a single running value, so the reported closing balance was whatever the last section happened to end at — not the rollup.

Observed on a parent credit card account: opening $13,898.67, net −$515.31, closing **$0.00**. That isn't arithmetically possible. $0.00 was the last sub-account's closing figure.

Every other field was already right, because they *sum* across sections. Only closing was overwritten rather than accumulated:

| account | opening | debits | credits | net | closing |
|---|---|---|---|---|---|
| 2101 | −1,302.72 | 13,786.89 | 28,472.97 | +14,686.08 | 13,383.36 |
| 2102 | 15,201.39 | 18,155.97 | 2,954.58 | −15,201.39 | 0.00 |
| 2103 | 0.00 | 168.41 | 168.41 | 0.00 | 0.00 |
| **sum** | **13,898.67** | **32,111.27** | **31,595.96** | **−515.31** | **13,383.36** |
| parent reports | 13,898.67 ✓ | 32,111.27 ✓ | 31,595.96 ✓ | −515.31 ✓ | **0.00 ✗** |

## The fix

Closing is now **derived as opening + net activity** instead of read from the Balance column.

That identity holds per section and per rollup, and it reproduces QBO's own per-section closing figures *exactly* — 13,383.36, 0.00 and 0.00 above — so it isn't a heuristic that happens to fit. It also removes the `transactionCount === 0` special case, which existed only to paper over the same weakness for an empty period.

Amounts now accumulate in **integer cents**, per the convention in `CLAUDE.md`. This handler summed floats across every row of a general ledger, which is precisely the case that convention exists for.

## Testing

`parseGLReport` is now exported so the arithmetic can be exercised directly rather than restated in a test. Run against a synthetic report shaped like the real one (three sub-account sections, each with its own Beginning Balance and its own restarting Balance column):

```
ok   opening               13898.67  expected 13898.67
ok   debits                32111.27  expected 32111.27
ok   credits               31595.96  expected 31595.96
ok   net                    -515.31  expected -515.31
ok   closing               13383.36  expected 13383.36
ok   txn count            6
ok   single closing        13383.36  expected 13383.36   <- case that already worked
ok   empty closing           500.00  expected 500.00     <- replaces the removed special case
ok   empty txn count      0
```

Builds and typecheck pass.

## Scope

Pre-existing, and **only wrong for accounts with sub-accounts** — a single-section report has exactly one Balance sequence, so the old code got those right. Anyone reading a closing balance on a parent account has been getting the wrong number.

## After merge

```
git switch master && git pull
npm publish
git tag v0.7.1 && git push --tags
mcp-publisher publish
```

Note the josiah Lambda builds from source, so the deployed HTTP server needs its own rebuild to pick this up — worth folding into the terraform push already in flight rather than doing twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
